### PR TITLE
VictoriaMetrics support

### DIFF
--- a/varken/dbmanager.py
+++ b/varken/dbmanager.py
@@ -30,9 +30,10 @@ class DBManager(object):
 
         try:
             version = self.influx.version()
-            # Alternative approach for VictoriaMetrics support
+            # Hack for VictoriaMetrics support
             if version == 'unknown':
-                version = self.influx.request('write', expected_response_code=204).headers['X-Influxdb-Version']
+                version = 'v1.8'
+                #version = self.influx.request('write', expected_response_code=204).headers['X-Influxdb-Version']
             self.logger.info('Influxdb version: %s', version)
             match = re.match(r'v?(\d+)\.', version)
             if match:

--- a/varken/dbmanager.py
+++ b/varken/dbmanager.py
@@ -30,7 +30,7 @@ class DBManager(object):
 
         try:
             version = self.influx.version()
-            # Alternative approach for victoria-metrics support
+            # Alternative approach for VictoriaMetrics support
             if not version:
                 version = self.influx.request('write', expected_response_code=204).headers['X-Influxdb-Version']
             self.logger.info('Influxdb version: %s', version)

--- a/varken/dbmanager.py
+++ b/varken/dbmanager.py
@@ -31,7 +31,7 @@ class DBManager(object):
         try:
             version = self.influx.version()
             # Alternative approach for VictoriaMetrics support
-            if not version:
+            if version == 'unknown':
                 version = self.influx.request('write', expected_response_code=204).headers['X-Influxdb-Version']
             self.logger.info('Influxdb version: %s', version)
             match = re.match(r'v?(\d+)\.', version)

--- a/varken/dbmanager.py
+++ b/varken/dbmanager.py
@@ -33,7 +33,6 @@ class DBManager(object):
             # Hack for VictoriaMetrics support
             if version == 'unknown':
                 version = 'v1.8'
-                #version = self.influx.request('write', expected_response_code=204).headers['X-Influxdb-Version']
             self.logger.info('Influxdb version: %s', version)
             match = re.match(r'v?(\d+)\.', version)
             if match:

--- a/varken/dbmanager.py
+++ b/varken/dbmanager.py
@@ -30,6 +30,9 @@ class DBManager(object):
 
         try:
             version = self.influx.version()
+            # Alternative approach for victoria-metrics support
+            if not version:
+                version = self.influx.request('write', expected_response_code=204).headers['X-Influxdb-Version']
             self.logger.info('Influxdb version: %s', version)
             match = re.match(r'v?(\d+)\.', version)
             if match:


### PR DESCRIPTION
This patch adds support for VictoriaMetrics, which is fully compatible with the 1.8 API. However, the version check needs to be adjusted.