### PR TITLE
fix(ombi): resolve requested_by user from Identity API

### DIFF
--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -1,4 +1,55 @@
 services:
+  # ===================
+  # Varken (auto-build from source)
+  # ===================
+  # Production build (from Dockerfile)
+  varken:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: varken
+    environment:
+      - TZ=Europe/Paris
+      - LOG_LEVEL=debug
+      - CONFIG_FOLDER=/config
+      - DATA_FOLDER=/data
+      - LOG_FOLDER=/logs
+    volumes:
+      - ./config/varken.test.yaml:/config/varken.yaml:ro
+      - ./data:/data
+      - ./logs:/logs
+    depends_on:
+      influxdb2:
+        condition: service_healthy
+    profiles:
+      - varken
+      - all
+
+  # Development mode (hot-reload with source mount)
+  varken-dev:
+    image: node:22-alpine
+    container_name: varken-dev
+    working_dir: /app
+    command: sh -c "npm install && npm run dev"
+    environment:
+      - TZ=Europe/Paris
+      - LOG_LEVEL=debug
+      - CONFIG_FOLDER=/config
+      - DATA_FOLDER=/app/data
+      - LOG_FOLDER=/app/logs
+    volumes:
+      - .:/app
+      - ./config/varken.test.yaml:/config/varken.yaml:ro
+      - varken-node-modules:/app/node_modules
+    depends_on:
+      influxdb2:
+        condition: service_healthy
+    profiles:
+      - dev
+
+  # ===================
+  # Database Services
+  # ===================
   influxdb1:
     image: influxdb:1.8
     container_name: varken-influxdb1
@@ -17,6 +68,10 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    profiles:
+      - influxdb1
+      - databases
+      - all
 
   influxdb2:
     image: influxdb:2.7
@@ -37,7 +92,191 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    profiles:
+      - influxdb2
+      - databases
+      - all
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: varken-grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_INSTALL_PLUGINS=grafana-piechart-panel
+    volumes:
+      - grafana-data:/var/lib/grafana
+    profiles:
+      - grafana
+      - databases
+      - all
+
+  # ===================
+  # Media Services
+  # ===================
+  ombi:
+    image: lscr.io/linuxserver/ombi:latest
+    container_name: varken-ombi
+    ports:
+      - "3579:3579"
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Europe/Paris
+    volumes:
+      - ombi-data:/config
+    profiles:
+      - ombi
+      - media
+      - all
+
+  sonarr:
+    image: lscr.io/linuxserver/sonarr:latest
+    container_name: varken-sonarr
+    ports:
+      - "8989:8989"
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Europe/Paris
+    volumes:
+      - sonarr-data:/config
+    profiles:
+      - sonarr
+      - arr
+      - media
+      - all
+
+  radarr:
+    image: lscr.io/linuxserver/radarr:latest
+    container_name: varken-radarr
+    ports:
+      - "7878:7878"
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Europe/Paris
+    volumes:
+      - radarr-data:/config
+    profiles:
+      - radarr
+      - arr
+      - media
+      - all
+
+  lidarr:
+    image: lscr.io/linuxserver/lidarr:latest
+    container_name: varken-lidarr
+    ports:
+      - "8686:8686"
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Europe/Paris
+    volumes:
+      - lidarr-data:/config
+    profiles:
+      - lidarr
+      - arr
+      - media
+      - all
+
+  readarr:
+    image: lscr.io/linuxserver/readarr:develop
+    container_name: varken-readarr
+    ports:
+      - "8787:8787"
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Europe/Paris
+    volumes:
+      - readarr-data:/config
+    profiles:
+      - readarr
+      - arr
+      - media
+      - all
+
+  prowlarr:
+    image: lscr.io/linuxserver/prowlarr:latest
+    container_name: varken-prowlarr
+    ports:
+      - "9696:9696"
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Europe/Paris
+    volumes:
+      - prowlarr-data:/config
+    profiles:
+      - prowlarr
+      - arr
+      - media
+      - all
+
+  bazarr:
+    image: lscr.io/linuxserver/bazarr:latest
+    container_name: varken-bazarr
+    ports:
+      - "6767:6767"
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Europe/Paris
+    volumes:
+      - bazarr-data:/config
+    profiles:
+      - bazarr
+      - arr
+      - media
+      - all
+
+  overseerr:
+    image: lscr.io/linuxserver/overseerr:latest
+    container_name: varken-overseerr
+    ports:
+      - "5055:5055"
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Europe/Paris
+    volumes:
+      - overseerr-data:/config
+    profiles:
+      - overseerr
+      - media
+      - all
+
+  tautulli:
+    image: lscr.io/linuxserver/tautulli:latest
+    container_name: varken-tautulli
+    ports:
+      - "8181:8181"
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Europe/Paris
+    volumes:
+      - tautulli-data:/config
+    profiles:
+      - tautulli
+      - media
+      - all
 
 volumes:
   influxdb1-data:
   influxdb2-data:
+  grafana-data:
+  ombi-data:
+  sonarr-data:
+  radarr-data:
+  lidarr-data:
+  readarr-data:
+  prowlarr-data:
+  bazarr-data:
+  overseerr-data:
+  tautulli-data:
+  varken-node-modules:

--- a/src/plugins/inputs/OmbiPlugin.ts
+++ b/src/plugins/inputs/OmbiPlugin.ts
@@ -6,6 +6,7 @@ import type {
   OmbiIssuesCounts,
   OmbiMovieRequest,
   OmbiTVRequest,
+  OmbiUser,
 } from '../../types/inputs/ombi.types';
 
 /**
@@ -169,21 +170,35 @@ export class OmbiPlugin extends BaseInputPlugin<OmbiConfig> {
   }
 
   /**
+   * Fetch users and build a map of userId -> displayName
+   */
+  private async fetchUserMap(): Promise<Map<string, string>> {
+    try {
+      const users = await this.httpGet<OmbiUser[]>('/api/v1/Identity/Users');
+      return new Map(users.map((u) => [u.id, u.alias || u.userName]));
+    } catch (error) {
+      this.logger.warn(`Failed to fetch Ombi users, falling back to alias: ${error}`);
+      return new Map();
+    }
+  }
+
+  /**
    * Collect all requests (TV and movie) from Ombi
    */
   private async collectAllRequests(): Promise<DataPoint[]> {
     const points: DataPoint[] = [];
 
     try {
-      // Fetch TV and movie requests in parallel
-      const [tvRequests, movieRequests] = await Promise.all([
+      // Fetch users and requests in parallel
+      const [userMap, tvRequests, movieRequests] = await Promise.all([
+        this.fetchUserMap(),
         this.httpGet<OmbiTVRequest[]>('/api/v1/Request/tv'),
         this.httpGet<OmbiMovieRequest[]>('/api/v1/Request/movie'),
       ]);
 
       // Process TV requests
       for (const request of tvRequests || []) {
-        const tvPoint = this.processTVRequest(request);
+        const tvPoint = this.processTVRequest(request, userMap);
         if (tvPoint) {
           points.push(tvPoint);
         }
@@ -191,7 +206,7 @@ export class OmbiPlugin extends BaseInputPlugin<OmbiConfig> {
 
       // Process movie requests
       for (const request of movieRequests || []) {
-        const moviePoint = this.processMovieRequest(request);
+        const moviePoint = this.processMovieRequest(request, userMap);
         if (moviePoint) {
           points.push(moviePoint);
         }
@@ -224,9 +239,24 @@ export class OmbiPlugin extends BaseInputPlugin<OmbiConfig> {
   }
 
   /**
+   * Resolve the requested user's display name
+   * Priority: userMap lookup > requestedByAlias > 'Unknown'
+   */
+  private resolveUserName(
+    userId: string | undefined,
+    alias: string | undefined,
+    userMap: Map<string, string>
+  ): string {
+    if (userId && userMap.has(userId)) {
+      return userMap.get(userId)!;
+    }
+    return alias || 'Unknown';
+  }
+
+  /**
    * Process a TV request into a DataPoint
    */
-  private processTVRequest(request: OmbiTVRequest): DataPoint | null {
+  private processTVRequest(request: OmbiTVRequest, userMap: Map<string, string>): DataPoint | null {
     if (!request.childRequests || request.childRequests.length === 0) {
       return null;
     }
@@ -241,7 +271,11 @@ export class OmbiPlugin extends BaseInputPlugin<OmbiConfig> {
     );
 
     const hashId = this.hashit(`${request.id}${request.tvDbId}${request.title}`);
-    const requestedUser = childRequest.requestedByAlias || 'Unknown';
+    const requestedUser = this.resolveUserName(
+      childRequest.requestedUserId,
+      childRequest.requestedByAlias,
+      userMap
+    );
     const requestedDate = childRequest.requestedDate || '';
 
     return this.createDataPoint(
@@ -264,11 +298,18 @@ export class OmbiPlugin extends BaseInputPlugin<OmbiConfig> {
   /**
    * Process a movie request into a DataPoint
    */
-  private processMovieRequest(request: OmbiMovieRequest): DataPoint | null {
+  private processMovieRequest(
+    request: OmbiMovieRequest,
+    userMap: Map<string, string>
+  ): DataPoint | null {
     const status = getRequestStatus(request.approved, request.available, request.denied || false);
 
     const hashId = this.hashit(`${request.id}${request.theMovieDbId}${request.title}`);
-    const requestedUser = request.requestedByAlias || 'Unknown';
+    const requestedUser = this.resolveUserName(
+      request.requestedUserId,
+      request.requestedByAlias,
+      userMap
+    );
     const requestedDate = request.requestedDate || '';
 
     return this.createDataPoint(

--- a/src/types/inputs/ombi.types.ts
+++ b/src/types/inputs/ombi.types.ts
@@ -18,6 +18,15 @@ export interface OmbiConfig {
   };
 }
 
+// API Response Types - /api/v1/Identity/Users
+export interface OmbiUser {
+  id: string;
+  userName: string;
+  alias?: string;
+  email?: string;
+  userType: number;
+}
+
 // API Response Types - /api/v1/Request/count
 export interface OmbiRequestCounts {
   approved: number;

--- a/tests/plugins/inputs/OmbiPlugin.test.ts
+++ b/tests/plugins/inputs/OmbiPlugin.test.ts
@@ -5,7 +5,14 @@ import {
   OmbiIssuesCounts,
   OmbiMovieRequest,
   OmbiTVRequest,
+  OmbiUser,
 } from '../../../src/types/inputs/ombi.types';
+
+// Mock users data
+const mockUsers: OmbiUser[] = [
+  { id: 'user1', userName: 'john_doe', alias: 'John', email: 'john@test.com', userType: 1 },
+  { id: 'user2', userName: 'jane_smith', email: 'jane@test.com', userType: 1 },
+];
 
 // Mock the logger
 vi.mock('../../../src/core/Logger', () => ({
@@ -113,6 +120,7 @@ describe('OmbiPlugin', () => {
         if (path === '/api/v1/Request/tv') return mockTVRequests;
         if (path === '/api/v1/Request/movie') return mockMovieRequests;
         if (path === '/api/v1/Issues/count') return { pending: 0, inProgress: 0, resolved: 0 };
+        if (path === '/api/v1/Identity/Users') return mockUsers;
         return null;
       });
 
@@ -138,6 +146,7 @@ describe('OmbiPlugin', () => {
         if (path === '/api/v1/Request/count') return { pending: 0, approved: 0, available: 0 };
         if (path === '/api/v1/Request/tv') return [];
         if (path === '/api/v1/Request/movie') return [];
+        if (path === '/api/v1/Identity/Users') return mockUsers;
         return null;
       });
 
@@ -174,6 +183,7 @@ describe('OmbiPlugin', () => {
         if (path === '/api/v1/Request/tv') return [];
         if (path === '/api/v1/Request/count') return { pending: 0, approved: 1, available: 1 };
         if (path === '/api/v1/Issues/count') return { pending: 0, inProgress: 0, resolved: 0 };
+        if (path === '/api/v1/Identity/Users') return mockUsers;
         return null;
       });
 
@@ -183,7 +193,8 @@ describe('OmbiPlugin', () => {
       expect(requestPoint).toBeDefined();
       expect(requestPoint?.tags.title).toBe('Test Movie');
       expect(requestPoint?.tags.status).toBe(2); // Completed (approved + available)
-      expect(requestPoint?.tags.requested_user).toBe('TestUser');
+      // user1 has alias 'John' in mockUsers, but requestedByAlias takes precedence when present
+      expect(requestPoint?.tags.requested_user).toBe('John');
       expect(requestPoint?.fields.hash).toBeDefined();
     });
 
@@ -221,6 +232,7 @@ describe('OmbiPlugin', () => {
         if (path === '/api/v1/Request/movie') return [];
         if (path === '/api/v1/Request/count') return { pending: 1, approved: 0, available: 0 };
         if (path === '/api/v1/Issues/count') return { pending: 0, inProgress: 0, resolved: 0 };
+        if (path === '/api/v1/Identity/Users') return mockUsers;
         return null;
       });
 
@@ -230,7 +242,8 @@ describe('OmbiPlugin', () => {
       expect(requestPoint).toBeDefined();
       expect(requestPoint?.tags.title).toBe('Test Show');
       expect(requestPoint?.tags.status).toBe(3); // Pending
-      expect(requestPoint?.tags.requested_user).toBe('AnotherUser');
+      // user2 has no alias, so userName 'jane_smith' should be used
+      expect(requestPoint?.tags.requested_user).toBe('jane_smith');
     });
 
     it('should create Request_Total summary', async () => {
@@ -291,6 +304,7 @@ describe('OmbiPlugin', () => {
         if (path === '/api/v1/Request/movie') return mockMovieRequests;
         if (path === '/api/v1/Request/count') return { pending: 3, approved: 0, available: 0 };
         if (path === '/api/v1/Issues/count') return { pending: 0, inProgress: 0, resolved: 0 };
+        if (path === '/api/v1/Identity/Users') return mockUsers;
         return null;
       });
 
@@ -327,6 +341,7 @@ describe('OmbiPlugin', () => {
         if (path === '/api/v1/Request/tv') return [];
         if (path === '/api/v1/Request/count') return { pending: 0, approved: 0, available: 0 };
         if (path === '/api/v1/Issues/count') return { pending: 0, inProgress: 0, resolved: 0 };
+        if (path === '/api/v1/Identity/Users') return mockUsers;
         return null;
       });
 
@@ -358,6 +373,7 @@ describe('OmbiPlugin', () => {
         if (path === '/api/v1/Request/tv') return [];
         if (path === '/api/v1/Request/count') return { pending: 0, approved: 1, available: 0 };
         if (path === '/api/v1/Issues/count') return { pending: 0, inProgress: 0, resolved: 0 };
+        if (path === '/api/v1/Identity/Users') return mockUsers;
         return null;
       });
 
@@ -386,6 +402,7 @@ describe('OmbiPlugin', () => {
         if (path === '/api/v1/Request/movie') return [];
         if (path === '/api/v1/Request/count') return { pending: 0, approved: 0, available: 0 };
         if (path === '/api/v1/Issues/count') return { pending: 0, inProgress: 0, resolved: 0 };
+        if (path === '/api/v1/Identity/Users') return mockUsers;
         return null;
       });
 
@@ -405,7 +422,7 @@ describe('OmbiPlugin', () => {
       expect(points).toEqual([]);
     });
 
-    it('should use Unknown for missing requestedByAlias', async () => {
+    it('should resolve userName from Identity API when alias is missing', async () => {
       const mockMovieRequests: OmbiMovieRequest[] = [
         {
           id: 1,
@@ -416,7 +433,7 @@ describe('OmbiPlugin', () => {
           approved: false,
           available: false,
           requestedDate: '2024-01-15',
-          requestedUserId: 'user1',
+          requestedUserId: 'user2', // user2 has no alias in mockUsers
           requestType: 1,
           // requestedByAlias is undefined
         },
@@ -428,6 +445,108 @@ describe('OmbiPlugin', () => {
         if (path === '/api/v1/Request/tv') return [];
         if (path === '/api/v1/Request/count') return { pending: 1, approved: 0, available: 0 };
         if (path === '/api/v1/Issues/count') return { pending: 0, inProgress: 0, resolved: 0 };
+        if (path === '/api/v1/Identity/Users') return mockUsers;
+        return null;
+      });
+
+      const points = await plugin.collect();
+
+      const requestPoint = points.find(p => p.tags.type === 'Requests');
+      // user2 has userName 'jane_smith' and no alias
+      expect(requestPoint?.tags.requested_user).toBe('jane_smith');
+    });
+
+    it('should use alias from Identity API when user has one', async () => {
+      const mockMovieRequests: OmbiMovieRequest[] = [
+        {
+          id: 1,
+          theMovieDbId: 123,
+          title: 'Movie With User Alias',
+          status: 'Pending',
+          requestStatus: 'Pending',
+          approved: false,
+          available: false,
+          requestedDate: '2024-01-15',
+          requestedUserId: 'user1', // user1 has alias 'John' in mockUsers
+          requestType: 1,
+        },
+      ];
+
+      const httpGetSpy = vi.spyOn(plugin as unknown as { httpGet: <T>(path: string) => Promise<T> }, 'httpGet');
+      httpGetSpy.mockImplementation(async (path: string) => {
+        if (path === '/api/v1/Request/movie') return mockMovieRequests;
+        if (path === '/api/v1/Request/tv') return [];
+        if (path === '/api/v1/Request/count') return { pending: 1, approved: 0, available: 0 };
+        if (path === '/api/v1/Issues/count') return { pending: 0, inProgress: 0, resolved: 0 };
+        if (path === '/api/v1/Identity/Users') return mockUsers;
+        return null;
+      });
+
+      const points = await plugin.collect();
+
+      const requestPoint = points.find(p => p.tags.type === 'Requests');
+      // user1 has alias 'John'
+      expect(requestPoint?.tags.requested_user).toBe('John');
+    });
+
+    it('should fallback to requestedByAlias when Identity API fails', async () => {
+      const mockMovieRequests: OmbiMovieRequest[] = [
+        {
+          id: 1,
+          theMovieDbId: 123,
+          title: 'Movie Fallback Alias',
+          status: 'Pending',
+          requestStatus: 'Pending',
+          approved: false,
+          available: false,
+          requestedDate: '2024-01-15',
+          requestedUserId: 'user1',
+          requestedByAlias: 'FallbackAlias',
+          requestType: 1,
+        },
+      ];
+
+      const httpGetSpy = vi.spyOn(plugin as unknown as { httpGet: <T>(path: string) => Promise<T> }, 'httpGet');
+      httpGetSpy.mockImplementation(async (path: string) => {
+        if (path === '/api/v1/Request/movie') return mockMovieRequests;
+        if (path === '/api/v1/Request/tv') return [];
+        if (path === '/api/v1/Request/count') return { pending: 1, approved: 0, available: 0 };
+        if (path === '/api/v1/Issues/count') return { pending: 0, inProgress: 0, resolved: 0 };
+        if (path === '/api/v1/Identity/Users') throw new Error('API Error');
+        return null;
+      });
+
+      const points = await plugin.collect();
+
+      const requestPoint = points.find(p => p.tags.type === 'Requests');
+      // Falls back to requestedByAlias when Identity API fails
+      expect(requestPoint?.tags.requested_user).toBe('FallbackAlias');
+    });
+
+    it('should use Unknown when userId not in userMap and no alias', async () => {
+      const mockMovieRequests: OmbiMovieRequest[] = [
+        {
+          id: 1,
+          theMovieDbId: 123,
+          title: 'Movie Unknown User',
+          status: 'Pending',
+          requestStatus: 'Pending',
+          approved: false,
+          available: false,
+          requestedDate: '2024-01-15',
+          requestedUserId: 'unknown_user', // Not in mockUsers
+          requestType: 1,
+          // requestedByAlias is undefined
+        },
+      ];
+
+      const httpGetSpy = vi.spyOn(plugin as unknown as { httpGet: <T>(path: string) => Promise<T> }, 'httpGet');
+      httpGetSpy.mockImplementation(async (path: string) => {
+        if (path === '/api/v1/Request/movie') return mockMovieRequests;
+        if (path === '/api/v1/Request/tv') return [];
+        if (path === '/api/v1/Request/count') return { pending: 1, approved: 0, available: 0 };
+        if (path === '/api/v1/Issues/count') return { pending: 0, inProgress: 0, resolved: 0 };
+        if (path === '/api/v1/Identity/Users') return mockUsers;
         return null;
       });
 
@@ -461,6 +580,7 @@ describe('OmbiPlugin', () => {
         if (path === '/api/v1/Request/tv') return [];
         if (path === '/api/v1/Request/count') return { pending: 1, approved: 0, available: 0 };
         if (path === '/api/v1/Issues/count') return { pending: 0, inProgress: 0, resolved: 0 };
+        if (path === '/api/v1/Identity/Users') return mockUsers;
         return null;
       });
 


### PR DESCRIPTION
## Description

Fixes the issue where `requested_user` always shows "Unknown" in Ombi requests.

The `requestedByAlias` field is only populated when users manually configure an alias in Ombi, which most users don't do. This PR fetches users from the `/api/v1/Identity/Users` endpoint and builds a userId → displayName map.

**Changes:**
- Add `OmbiUser` interface for Identity API response
- Add `fetchUserMap()` method to retrieve users from Identity API
- Add `resolveUserName()` helper with three-tier fallback:
  1. User's alias/userName from Identity API
  2. `requestedByAlias` field (fallback if API fails)
  3. "Unknown" as last resort
- Fetch users in parallel with requests for performance

**Also includes:**
- Docker Compose test infrastructure with profiles for all supported services

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [ ] Dependencies update

## Checklist
- [x] I have tested my changes locally
- [x] I have added/updated tests if needed
- [x] Code coverage is maintained or improved
- [x] Lint passes (`npm run lint`)
- [x] Tests pass (`npm test`)

## Related Issues

Fixes #22