### PR TITLE
fix(output): escape backslashes in InfluxDB line protocol strings

### DIFF
--- a/src/plugins/outputs/BaseOutputPlugin.ts
+++ b/src/plugins/outputs/BaseOutputPlugin.ts
@@ -138,8 +138,8 @@ export abstract class BaseOutputPlugin<TConfig extends BaseOutputConfig = BaseOu
       return String(value);
     }
 
-    // Strings need to be quoted
-    const escaped = String(value).replace(/"/g, '\\"');
+    // Strings need to be quoted and escaped (backslashes first, then quotes)
+    const escaped = String(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
     return `"${escaped}"`;
   }
 

--- a/tests/plugins/outputs/BaseOutputPlugin.test.ts
+++ b/tests/plugins/outputs/BaseOutputPlugin.test.ts
@@ -186,6 +186,30 @@ describe('BaseOutputPlugin', () => {
       expect(result).toContain('message="He said \\"hello\\""');
     });
 
+    it('should escape backslashes in string fields', () => {
+      const point: DataPoint = {
+        measurement: 'test',
+        tags: {},
+        fields: { path: 'C:\\Users\\test' },
+        timestamp: new Date('2024-01-15T10:30:00.000Z'),
+      };
+
+      const result = plugin.testToLineProtocol(point);
+      expect(result).toContain('path="C:\\\\Users\\\\test"');
+    });
+
+    it('should escape both backslashes and quotes in string fields', () => {
+      const point: DataPoint = {
+        measurement: 'test',
+        tags: {},
+        fields: { value: 'path "C:\\test"' },
+        timestamp: new Date('2024-01-15T10:30:00.000Z'),
+      };
+
+      const result = plugin.testToLineProtocol(point);
+      expect(result).toContain('value="path \\"C:\\\\test\\""');
+    });
+
     it('should skip null/undefined/empty tag values', () => {
       const point: DataPoint = {
         measurement: 'test',


### PR DESCRIPTION
## Description
Fix incomplete string sanitization in `BaseOutputPlugin.ts` where only double quotes were escaped but not backslashes. InfluxDB line protocol requires both to be escaped in string field values.

Example: `C:\Users\test` → `"C:\\Users\\test"`

## Type of change
- [x] Bug fix

## Checklist
- [x] I have tested my changes locally
- [x] I have added/updated tests if needed
- [x] Code coverage is maintained or improved
- [x] Lint passes (`npm run lint`)
- [x] Tests pass (`npm test`)

## Related Issues
Fixes CodeQL alert #8 (js/incomplete-sanitization)