### PR TITLE
feat(core): implement complete circuit breaker with exponential backoff and self-healing

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -68,7 +68,7 @@ varken/
 │   └── utils/
 │       ├── http.ts                  # HTTP utilities, error classification
 │       └── index.ts
-├── tests/                           # 453 tests, 90% coverage
+├── tests/                           # 468 tests, 90% coverage
 │   ├── config/
 │   ├── core/
 │   ├── plugins/
@@ -254,14 +254,13 @@ interface ScheduleConfig {
   - Add `prom-client` dependency
   - Effort: ~8h
 
-#### Circuit Breaker & Error Recovery (Partially Done)
-- [x] Track consecutive failures per schedule (`PluginManager.ts:281`)
+#### Circuit Breaker & Error Recovery ✅
+- [x] Track consecutive failures per schedule (`PluginManager.ts`)
 - [x] Exponential backoff on HTTP retries (`http.ts:84`)
-- [x] Mark plugin as degraded after 3+ errors (`HealthServer.ts:239`)
-- [ ] Add scheduler-level backoff (increase interval after failures)
-- [ ] Auto-disable failing plugins after N errors (configurable)
-- [ ] Re-enable plugins after cooldown period
-- Effort: ~4h (remaining work)
+- [x] Mark plugin as degraded after 3+ errors (`HealthServer.ts`)
+- [x] Scheduler-level backoff (increase interval after failures)
+- [x] Auto-disable failing plugins after N errors (configurable)
+- [x] Re-enable plugins after cooldown period with half-open recovery
 
 #### Config Hot-Reload
 - [ ] Watch config file for changes with `fs.watch()`
@@ -526,9 +525,8 @@ DataPoint (internal format)
 | Item | Effort | Impact |
 |------|--------|--------|
 | ~~Health endpoint~~ | ~~✅~~ | ~~Production readiness~~ |
-| ~~Circuit breaker (partial)~~ | ~~✅~~ | ~~Error tracking, degraded status~~ |
+| ~~Circuit breaker~~ | ~~✅~~ | ~~Error tracking, auto-disable, scheduler backoff~~ |
 | VictoriaMetrics output | ~4h | Popular alternative DB |
-| Circuit breaker (complete) | ~4h | Auto-disable, scheduler backoff |
 | ~~Test Logger (42% → 84%)~~ | ~~✅~~ | ~~Critical coverage gap~~ |
 | ~~Test entry point (0% → 100%)~~ | ~~✅~~ | ~~Coverage~~ |
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 - **GeoIP mapping** - Automatic geolocation of streaming sessions via Tautulli API (no external license required)
 - **Multi-instance support** - Connect multiple instances of each service
 - **Health checks** - Built-in HTTP health endpoints for monitoring and orchestration
+- **Circuit breaker** - Automatic error recovery with backoff and self-healing
 - **Docker ready** - Multi-platform images for amd64 and arm64
 - **Easy configuration** - Simple YAML configuration with environment variable overrides
 
@@ -36,6 +37,7 @@
   - [Environment Variables](#environment-variables)
   - [GeoIP Setup](#geoip-setup)
   - [Multiple Instances](#multiple-instances)
+  - [Circuit Breaker](#circuit-breaker)
 - [Health Checks](#health-checks)
 - [Supported Services](#supported-services)
 - [Grafana Setup](#grafana-setup)
@@ -255,6 +257,95 @@ inputs:
 
 Each instance must have a unique `id`.
 
+### Circuit Breaker
+
+Varken includes a built-in circuit breaker to handle failing services gracefully. When a scheduler encounters repeated errors, the circuit breaker:
+
+1. **Applies backoff** - Increases the interval between retries (exponential backoff)
+2. **Opens the circuit** - Temporarily disables the failing scheduler after too many errors
+3. **Attempts recovery** - After a cooldown period, tests if the service has recovered
+4. **Closes the circuit** - Returns to normal operation after successful recovery
+
+#### Configuration
+
+The circuit breaker is optional and has sensible defaults:
+
+```yaml
+circuitBreaker:
+  # Errors before disabling scheduler (default: 10)
+  maxConsecutiveErrors: 10
+
+  # Interval multiplier per failure (default: 2)
+  # Example: 30s → 60s → 120s → 240s...
+  backoffMultiplier: 2
+
+  # Maximum interval cap in seconds (default: 600 = 10 min)
+  maxIntervalSeconds: 600
+
+  # Cooldown before recovery attempt in seconds (default: 300 = 5 min)
+  cooldownSeconds: 300
+
+  # Successes needed to fully recover (default: 3)
+  recoverySuccesses: 3
+```
+
+#### State Machine
+
+```
+CLOSED (normal) ──[errors]──► OPEN (disabled)
+                                    │
+                              [cooldown]
+                                    │
+                                    ▼
+                              HALF-OPEN (testing)
+                                    │
+                    ┌───────────────┼───────────────┐
+                    │               │               │
+              [success x N]    [failure]      [success]
+                    │               │               │
+                    ▼               ▼               │
+                 CLOSED          OPEN              │
+                                    ▲               │
+                                    └───────────────┘
+```
+
+#### Monitoring
+
+Circuit breaker states are visible in the `/status` endpoint:
+
+```json
+{
+  "schedulers": [
+    {
+      "name": "sonarr_1_queue",
+      "circuitState": "closed",
+      "currentIntervalSeconds": 30,
+      "consecutiveErrors": 0,
+      "recoverySuccesses": 0,
+      "nextRunAt": "2024-01-15T10:30:30.000Z"
+    }
+  ]
+}
+```
+
+When a circuit is open:
+
+```json
+{
+  "schedulers": [
+    {
+      "name": "sonarr_1_queue",
+      "circuitState": "open",
+      "currentIntervalSeconds": 120,
+      "consecutiveErrors": 10,
+      "disabledAt": "2024-01-15T10:30:00.000Z",
+      "nextAttemptAt": "2024-01-15T10:35:00.000Z",
+      "nextRunAt": "2024-01-15T10:35:00.000Z"
+    }
+  ]
+}
+```
+
 ## Health Checks
 
 Varken exposes HTTP endpoints for monitoring on port `9090` (configurable via `HEALTH_PORT`):
@@ -277,9 +368,9 @@ The Docker image includes a built-in `HEALTHCHECK` instruction using these endpo
 
 | Status | Condition |
 |--------|-----------|
-| `healthy` | All outputs healthy + all inputs healthy + no scheduler with 3+ consecutive errors |
-| `degraded` | At least one output healthy + at least one input healthy or scheduler working |
-| `unhealthy` | No outputs configured, all outputs/inputs unreachable |
+| `healthy` | All outputs healthy + all inputs healthy + all schedulers in `closed` state with < 3 errors |
+| `degraded` | At least one output healthy + at least one scheduler not in `open` state |
+| `unhealthy` | No outputs configured, all outputs unreachable, or all schedulers in `open` state |
 
 ## Supported Services
 

--- a/config/varken.example.yaml
+++ b/config/varken.example.yaml
@@ -228,3 +228,29 @@ inputs:
   #       enabled: true
   #       count: 10
   #       intervalSeconds: 300
+
+# =============================================================================
+# CIRCUIT BREAKER - Error recovery configuration (optional)
+# =============================================================================
+# The circuit breaker automatically handles failing schedulers by:
+# 1. Applying exponential backoff on errors (increasing interval between retries)
+# 2. Disabling schedulers after too many consecutive errors
+# 3. Re-enabling them after a cooldown period with gradual recovery
+#
+# State machine: CLOSED (normal) → OPEN (disabled) → HALF-OPEN (recovery) → CLOSED
+
+# circuitBreaker:
+#   # Number of consecutive errors before disabling a scheduler
+#   maxConsecutiveErrors: 10
+#
+#   # Interval multiplier applied after each failure (e.g., 30s → 60s → 120s)
+#   backoffMultiplier: 2
+#
+#   # Maximum interval cap in seconds (prevents intervals from growing too large)
+#   maxIntervalSeconds: 600  # 10 minutes
+#
+#   # How long to wait before attempting recovery (in seconds)
+#   cooldownSeconds: 300  # 5 minutes
+#
+#   # Number of successful executions needed to fully recover from half-open state
+#   recoverySuccesses: 3

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -18,6 +18,8 @@ services:
       - ./config/varken.test.yaml:/config/varken.yaml:ro
       - ./data:/data
       - ./logs:/logs
+    ports:
+      - "9090:9090"
     depends_on:
       influxdb2:
         condition: service_healthy
@@ -41,6 +43,8 @@ services:
       - .:/app
       - ./config/varken.test.yaml:/config/varken.yaml:ro
       - varken-node-modules:/app/node_modules
+    ports:
+      - "9090:9090"
     depends_on:
       influxdb2:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       - ./config:/config
       - ./data:/data
       - ./logs:/logs
+    ports:
+      - "9090:9090"
     depends_on:
       influxdb:
         condition: service_healthy

--- a/src/config/schemas/config.schema.ts
+++ b/src/config/schemas/config.schema.ts
@@ -206,6 +206,23 @@ export const OverseerrConfigSchema = z.object({
 });
 
 // =============================================================================
+// Circuit Breaker Schema
+// =============================================================================
+
+export const CircuitBreakerConfigSchema = z.object({
+  /** Number of consecutive errors before disabling scheduler */
+  maxConsecutiveErrors: z.number().min(1).default(10),
+  /** Interval multiplier per failure */
+  backoffMultiplier: z.number().min(1).default(2),
+  /** Maximum interval cap in seconds */
+  maxIntervalSeconds: z.number().min(1).default(600),
+  /** Wait time before recovery attempt in seconds */
+  cooldownSeconds: z.number().min(1).default(300),
+  /** Number of successes needed to fully recover */
+  recoverySuccesses: z.number().min(1).default(3),
+});
+
+// =============================================================================
 // Main Config Schema
 // =============================================================================
 
@@ -241,6 +258,7 @@ export const InputsConfigSchema = z.object({
 export const VarkenConfigSchema = z.object({
   outputs: OutputsConfigSchema,
   inputs: InputsConfigSchema,
+  circuitBreaker: CircuitBreakerConfigSchema.optional(),
 });
 
 // Type exports

--- a/src/core/HealthServer.ts
+++ b/src/core/HealthServer.ts
@@ -234,11 +234,20 @@ export class HealthServer {
     const inputsHealthy = inputHealthValues.length === 0 || inputHealthValues.every((h) => h);
     const someInputsHealthy = inputHealthValues.length === 0 || inputHealthValues.some((h) => h);
 
-    // Check if any scheduler has consecutive errors (3+ = failing)
+    // Check if any scheduler has consecutive errors (3+ = failing) or circuit is open
     const schedulersHealthy = schedulerStatuses.length === 0 ||
-      schedulerStatuses.every((s) => s.consecutiveErrors < 3);
+      schedulerStatuses.every((s) => s.consecutiveErrors < 3 && s.circuitState === 'closed');
     const someSchedulersHealthy = schedulerStatuses.length === 0 ||
-      schedulerStatuses.some((s) => s.consecutiveErrors < 3);
+      schedulerStatuses.some((s) => s.consecutiveErrors < 3 && s.circuitState !== 'open');
+
+    // Check if all schedulers have open circuits (all disabled)
+    const allSchedulersDisabled = schedulerStatuses.length > 0 &&
+      schedulerStatuses.every((s) => s.circuitState === 'open');
+
+    // All schedulers disabled = unhealthy
+    if (allSchedulersDisabled) {
+      return 'unhealthy';
+    }
 
     if (outputsHealthy && inputsHealthy && schedulersHealthy) {
       return 'healthy';

--- a/src/core/PluginManager.ts
+++ b/src/core/PluginManager.ts
@@ -5,7 +5,12 @@ import type {
   DataPoint,
   ScheduleConfig,
 } from '../types/plugin.types';
-import type { SchedulerStatus, PluginStatus } from '../types/health.types';
+import type {
+  SchedulerStatus,
+  PluginStatus,
+  CircuitBreakerState,
+  CircuitBreakerConfig,
+} from '../types/health.types';
 import type { VarkenConfig } from '../config/schemas/config.schema';
 
 const logger = createLogger('PluginManager');
@@ -21,6 +26,17 @@ export type InputPluginFactory = new () => InputPlugin;
 export type OutputPluginFactory = new () => OutputPlugin;
 
 /**
+ * Default circuit breaker configuration
+ */
+const DEFAULT_CIRCUIT_BREAKER_CONFIG: CircuitBreakerConfig = {
+  maxConsecutiveErrors: 10,
+  backoffMultiplier: 2,
+  maxIntervalSeconds: 600,
+  cooldownSeconds: 300,
+  recoverySuccesses: 3,
+};
+
+/**
  * Active scheduler information
  */
 interface ActiveScheduler {
@@ -31,6 +47,18 @@ interface ActiveScheduler {
   lastRunAt?: Date;
   lastError?: string;
   consecutiveErrors: number;
+  /** Circuit breaker state */
+  circuitState: CircuitBreakerState;
+  /** Current interval in milliseconds (may differ from base due to backoff) */
+  currentIntervalMs: number;
+  /** Base interval in milliseconds */
+  baseIntervalMs: number;
+  /** When the circuit was opened (disabled) */
+  disabledAt?: Date;
+  /** When the next recovery attempt will be made */
+  nextAttemptAt?: Date;
+  /** Number of successful recoveries in half-open state */
+  recoverySuccesses: number;
 }
 
 /**
@@ -46,6 +74,7 @@ export class PluginManager {
 
   private schedulers: Map<string, ActiveScheduler> = new Map();
   private isRunning = false;
+  private circuitBreakerConfig: CircuitBreakerConfig = DEFAULT_CIRCUIT_BREAKER_CONFIG;
 
   constructor() {
     // No longer needs GeoIP handler - handled by TautulliPlugin via Tautulli API
@@ -72,6 +101,14 @@ export class PluginManager {
    */
   async initializeFromConfig(config: VarkenConfig): Promise<void> {
     logger.info('Initializing plugins from configuration...');
+
+    // Store circuit breaker config with defaults
+    if (config.circuitBreaker) {
+      this.circuitBreakerConfig = {
+        ...DEFAULT_CIRCUIT_BREAKER_CONFIG,
+        ...config.circuitBreaker,
+      };
+    }
 
     // Initialize output plugins first
     await this.initializeOutputPlugins(config.outputs);
@@ -193,26 +230,50 @@ export class PluginManager {
   private startScheduler(schedule: ScheduleConfig, plugin: InputPlugin): void {
     const intervalMs = schedule.intervalSeconds * 1000;
 
-    // Run immediately on start
-    this.executeSchedule(schedule, plugin);
-
-    // Then run on interval
-    const timer = setInterval(() => {
-      this.executeSchedule(schedule, plugin);
-    }, intervalMs);
-
     const activeScheduler: ActiveScheduler = {
       schedule,
       plugin,
-      timer,
+      timer: null as unknown as NodeJS.Timeout, // Will be set by scheduleNextRun
       isRunning: false,
       consecutiveErrors: 0,
+      circuitState: 'closed',
+      currentIntervalMs: intervalMs,
+      baseIntervalMs: intervalMs,
+      recoverySuccesses: 0,
     };
 
     this.schedulers.set(schedule.name, activeScheduler);
+
+    // Run immediately on start
+    this.executeSchedule(schedule, plugin);
+
+    // Then schedule next run
+    activeScheduler.timer = this.scheduleNextRun(schedule, plugin, intervalMs);
+
     logger.info(
       `Started scheduler: ${schedule.name} (every ${schedule.intervalSeconds}s)`
     );
+  }
+
+  /**
+   * Schedule the next run using setTimeout for dynamic intervals
+   */
+  private scheduleNextRun(
+    schedule: ScheduleConfig,
+    plugin: InputPlugin,
+    intervalMs: number
+  ): NodeJS.Timeout {
+    return setTimeout(async () => {
+      await this.executeSchedule(schedule, plugin);
+      const scheduler = this.schedulers.get(schedule.name);
+      if (scheduler && this.isRunning) {
+        scheduler.timer = this.scheduleNextRun(
+          schedule,
+          plugin,
+          scheduler.currentIntervalMs
+        );
+      }
+    }, intervalMs);
   }
 
   /**
@@ -223,16 +284,28 @@ export class PluginManager {
     _plugin: InputPlugin
   ): Promise<void> {
     const scheduler = this.schedulers.get(schedule.name);
+    if (!scheduler) {return;}
 
     // Skip if already running (prevent overlap)
-    if (scheduler?.isRunning) {
+    if (scheduler.isRunning) {
       logger.debug(`Schedule ${schedule.name} is already running, skipping`);
       return;
     }
 
-    if (scheduler) {
-      scheduler.isRunning = true;
+    // Handle circuit breaker states
+    if (scheduler.circuitState === 'open') {
+      const now = Date.now();
+      if (scheduler.nextAttemptAt && now < scheduler.nextAttemptAt.getTime()) {
+        logger.debug(
+          `Schedule ${schedule.name} circuit is open, waiting until ${scheduler.nextAttemptAt.toISOString()}`
+        );
+        return;
+      }
+      // Cooldown period has passed, transition to half-open
+      this.transitionToHalfOpen(scheduler);
     }
+
+    scheduler.isRunning = true;
 
     try {
       logger.debug(`Executing schedule: ${schedule.name}`);
@@ -252,27 +325,131 @@ export class PluginManager {
         logger.debug(`Schedule ${schedule.name} collected no data`);
       }
 
-      // Reset error tracking on success
-      if (scheduler) {
-        scheduler.lastRunAt = new Date();
-        scheduler.lastError = undefined;
-        scheduler.consecutiveErrors = 0;
-      }
+      // Handle success
+      this.handleScheduleSuccess(scheduler);
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error';
       logger.error(`Schedule ${schedule.name} failed: ${message}`);
 
-      // Track error
-      if (scheduler) {
-        scheduler.lastRunAt = new Date();
-        scheduler.lastError = message;
-        scheduler.consecutiveErrors++;
-      }
+      // Handle failure
+      this.handleScheduleFailure(scheduler, message);
     } finally {
-      if (scheduler) {
-        scheduler.isRunning = false;
+      scheduler.isRunning = false;
+    }
+  }
+
+  /**
+   * Handle successful schedule execution
+   */
+  private handleScheduleSuccess(scheduler: ActiveScheduler): void {
+    scheduler.lastRunAt = new Date();
+    scheduler.lastError = undefined;
+
+    if (scheduler.circuitState === 'half-open') {
+      scheduler.recoverySuccesses++;
+      logger.debug(
+        `Schedule ${scheduler.schedule.name} recovery success ${scheduler.recoverySuccesses}/${this.circuitBreakerConfig.recoverySuccesses}`
+      );
+
+      if (scheduler.recoverySuccesses >= this.circuitBreakerConfig.recoverySuccesses) {
+        // Fully recovered, close the circuit
+        this.closeCircuit(scheduler);
+      }
+    } else {
+      // Normal operation, reset everything
+      scheduler.consecutiveErrors = 0;
+      scheduler.currentIntervalMs = scheduler.baseIntervalMs;
+    }
+  }
+
+  /**
+   * Handle failed schedule execution
+   */
+  private handleScheduleFailure(scheduler: ActiveScheduler, errorMessage: string): void {
+    scheduler.lastRunAt = new Date();
+    scheduler.lastError = errorMessage;
+    scheduler.consecutiveErrors++;
+
+    if (scheduler.circuitState === 'half-open') {
+      // Recovery failed, go back to open state
+      logger.warn(
+        `Schedule ${scheduler.schedule.name} recovery failed, reopening circuit`
+      );
+      this.openCircuit(scheduler);
+    } else if (scheduler.circuitState === 'closed') {
+      // Check if we should open the circuit
+      if (scheduler.consecutiveErrors >= this.circuitBreakerConfig.maxConsecutiveErrors) {
+        this.openCircuit(scheduler);
+      } else {
+        // Apply backoff
+        this.applyBackoff(scheduler);
       }
     }
+  }
+
+  /**
+   * Apply exponential backoff to scheduler interval
+   */
+  private applyBackoff(scheduler: ActiveScheduler): void {
+    const maxIntervalMs = this.circuitBreakerConfig.maxIntervalSeconds * 1000;
+    const newIntervalMs = Math.min(
+      scheduler.currentIntervalMs * this.circuitBreakerConfig.backoffMultiplier,
+      maxIntervalMs
+    );
+
+    if (newIntervalMs !== scheduler.currentIntervalMs) {
+      scheduler.currentIntervalMs = newIntervalMs;
+      logger.debug(
+        `Schedule ${scheduler.schedule.name} backoff applied, interval now ${newIntervalMs / 1000}s`
+      );
+    }
+  }
+
+  /**
+   * Open the circuit (disable scheduler temporarily)
+   */
+  private openCircuit(scheduler: ActiveScheduler): void {
+    scheduler.circuitState = 'open';
+    scheduler.disabledAt = new Date();
+    scheduler.nextAttemptAt = new Date(
+      Date.now() + this.circuitBreakerConfig.cooldownSeconds * 1000
+    );
+    scheduler.recoverySuccesses = 0;
+
+    logger.warn(
+      `Schedule ${scheduler.schedule.name} circuit opened after ${scheduler.consecutiveErrors} errors, ` +
+      `next attempt at ${scheduler.nextAttemptAt.toISOString()}`
+    );
+  }
+
+  /**
+   * Transition circuit to half-open state for recovery testing
+   */
+  private transitionToHalfOpen(scheduler: ActiveScheduler): void {
+    scheduler.circuitState = 'half-open';
+    scheduler.recoverySuccesses = 0;
+    // Reset to base interval for recovery testing
+    scheduler.currentIntervalMs = scheduler.baseIntervalMs;
+
+    logger.info(
+      `Schedule ${scheduler.schedule.name} circuit transitioning to half-open for recovery testing`
+    );
+  }
+
+  /**
+   * Close the circuit (return to normal operation)
+   */
+  private closeCircuit(scheduler: ActiveScheduler): void {
+    scheduler.circuitState = 'closed';
+    scheduler.consecutiveErrors = 0;
+    scheduler.currentIntervalMs = scheduler.baseIntervalMs;
+    scheduler.disabledAt = undefined;
+    scheduler.nextAttemptAt = undefined;
+    scheduler.recoverySuccesses = 0;
+
+    logger.info(
+      `Schedule ${scheduler.schedule.name} circuit closed, resuming normal operation`
+    );
   }
 
   /**
@@ -307,7 +484,7 @@ export class PluginManager {
 
     // Clear all timers
     for (const [name, scheduler] of this.schedulers) {
-      clearInterval(scheduler.timer);
+      clearTimeout(scheduler.timer);
       logger.debug(`Stopped scheduler: ${name}`);
     }
 
@@ -427,6 +604,14 @@ export class PluginManager {
     const statuses: SchedulerStatus[] = [];
 
     for (const [, scheduler] of this.schedulers) {
+      // Calculate next run time
+      let nextRunAt: Date | undefined;
+      if (scheduler.circuitState === 'open') {
+        nextRunAt = scheduler.nextAttemptAt;
+      } else if (scheduler.lastRunAt) {
+        nextRunAt = new Date(scheduler.lastRunAt.getTime() + scheduler.currentIntervalMs);
+      }
+
       statuses.push({
         name: scheduler.schedule.name,
         pluginName: scheduler.plugin.metadata.name,
@@ -435,6 +620,12 @@ export class PluginManager {
         lastRunAt: scheduler.lastRunAt,
         lastError: scheduler.lastError,
         consecutiveErrors: scheduler.consecutiveErrors,
+        circuitState: scheduler.circuitState,
+        currentIntervalSeconds: scheduler.currentIntervalMs / 1000,
+        disabledAt: scheduler.disabledAt,
+        nextAttemptAt: scheduler.nextAttemptAt,
+        recoverySuccesses: scheduler.recoverySuccesses,
+        nextRunAt,
       });
     }
 

--- a/src/plugins/inputs/BazarrPlugin.ts
+++ b/src/plugins/inputs/BazarrPlugin.ts
@@ -160,6 +160,7 @@ export class BazarrPlugin extends BaseInputPlugin<BazarrConfig> {
       this.logger.info(`Collected ${points.length} wanted subtitles from Bazarr`);
     } catch (error) {
       this.logger.error(`Failed to collect Bazarr wanted subtitles: ${error}`);
+      throw error;
     }
 
     return points;
@@ -249,6 +250,7 @@ export class BazarrPlugin extends BaseInputPlugin<BazarrConfig> {
       this.logger.info(`Collected ${points.length} history items from Bazarr`);
     } catch (error) {
       this.logger.error(`Failed to collect Bazarr history: ${error}`);
+      throw error;
     }
 
     return points;

--- a/src/plugins/inputs/LidarrPlugin.ts
+++ b/src/plugins/inputs/LidarrPlugin.ts
@@ -140,6 +140,7 @@ export class LidarrPlugin extends BaseInputPlugin<LidarrConfig> {
       this.logger.info(`Collected ${points.length} queue items from Lidarr`);
     } catch (error) {
       this.logger.error(`Failed to collect Lidarr queue: ${error}`);
+      throw error;
     }
 
     return points;
@@ -192,6 +193,7 @@ export class LidarrPlugin extends BaseInputPlugin<LidarrConfig> {
       this.logger.info(`Collected ${points.length} missing albums from Lidarr`);
     } catch (error) {
       this.logger.error(`Failed to collect Lidarr missing albums: ${error}`);
+      throw error;
     }
 
     return points;

--- a/src/plugins/inputs/OmbiPlugin.ts
+++ b/src/plugins/inputs/OmbiPlugin.ts
@@ -132,6 +132,7 @@ export class OmbiPlugin extends BaseInputPlugin<OmbiConfig> {
       this.logger.info('Collected request counts from Ombi');
     } catch (error) {
       this.logger.error(`Failed to collect Ombi request counts: ${error}`);
+      throw error;
     }
 
     return points;
@@ -164,6 +165,7 @@ export class OmbiPlugin extends BaseInputPlugin<OmbiConfig> {
       this.logger.info('Collected issue counts from Ombi');
     } catch (error) {
       this.logger.error(`Failed to collect Ombi issue counts: ${error}`);
+      throw error;
     }
 
     return points;
@@ -233,6 +235,7 @@ export class OmbiPlugin extends BaseInputPlugin<OmbiConfig> {
       );
     } catch (error) {
       this.logger.error(`Failed to collect Ombi requests: ${error}`);
+      throw error;
     }
 
     return points;

--- a/src/plugins/inputs/OverseerrPlugin.ts
+++ b/src/plugins/inputs/OverseerrPlugin.ts
@@ -122,6 +122,7 @@ export class OverseerrPlugin extends BaseInputPlugin<OverseerrConfig> {
       this.logger.info('Collected request counts from Overseerr');
     } catch (error) {
       this.logger.error(`Failed to collect Overseerr request counts: ${error}`);
+      throw error;
     }
 
     return points;
@@ -158,6 +159,7 @@ export class OverseerrPlugin extends BaseInputPlugin<OverseerrConfig> {
       this.logger.info('Collected issue counts from Overseerr');
     } catch (error) {
       this.logger.error(`Failed to collect Overseerr issue counts: ${error}`);
+      throw error;
     }
 
     return points;
@@ -241,6 +243,7 @@ export class OverseerrPlugin extends BaseInputPlugin<OverseerrConfig> {
       this.logger.info(`Collected ${points.length} latest requests from Overseerr`);
     } catch (error) {
       this.logger.error(`Failed to collect Overseerr latest requests: ${error}`);
+      throw error;
     }
 
     return points;

--- a/src/plugins/inputs/ProwlarrPlugin.ts
+++ b/src/plugins/inputs/ProwlarrPlugin.ts
@@ -107,6 +107,7 @@ export class ProwlarrPlugin extends BaseInputPlugin<ProwlarrConfig> {
       this.logger.info(`Collected stats for ${points.length} indexers from Prowlarr`);
     } catch (error) {
       this.logger.error(`Failed to collect Prowlarr indexer stats: ${error}`);
+      throw error;
     }
 
     return points;

--- a/src/plugins/inputs/RadarrPlugin.ts
+++ b/src/plugins/inputs/RadarrPlugin.ts
@@ -141,6 +141,7 @@ export class RadarrPlugin extends BaseInputPlugin<RadarrConfig> {
       this.logger.info(`Collected ${points.length} queue items from Radarr`);
     } catch (error) {
       this.logger.error(`Failed to collect Radarr queue: ${error}`);
+      throw error;
     }
 
     return points;
@@ -193,6 +194,7 @@ export class RadarrPlugin extends BaseInputPlugin<RadarrConfig> {
       this.logger.info(`Collected ${points.length} missing movies from Radarr`);
     } catch (error) {
       this.logger.error(`Failed to collect Radarr missing movies: ${error}`);
+      throw error;
     }
 
     return points;

--- a/src/plugins/inputs/ReadarrPlugin.ts
+++ b/src/plugins/inputs/ReadarrPlugin.ts
@@ -143,6 +143,7 @@ export class ReadarrPlugin extends BaseInputPlugin<ReadarrConfig> {
       this.logger.info(`Collected ${points.length} queue items from Readarr`);
     } catch (error) {
       this.logger.error(`Failed to collect Readarr queue: ${error}`);
+      throw error;
     }
 
     return points;
@@ -194,6 +195,7 @@ export class ReadarrPlugin extends BaseInputPlugin<ReadarrConfig> {
       this.logger.info(`Collected ${points.length} missing books from Readarr`);
     } catch (error) {
       this.logger.error(`Failed to collect Readarr missing books: ${error}`);
+      throw error;
     }
 
     return points;

--- a/src/plugins/inputs/SonarrPlugin.ts
+++ b/src/plugins/inputs/SonarrPlugin.ts
@@ -158,6 +158,7 @@ export class SonarrPlugin extends BaseInputPlugin<SonarrConfig> {
       this.logger.info(`Collected ${points.length} queue items from Sonarr`);
     } catch (error) {
       this.logger.error(`Failed to collect Sonarr queue: ${error}`);
+      throw error;
     }
 
     return points;
@@ -240,6 +241,7 @@ export class SonarrPlugin extends BaseInputPlugin<SonarrConfig> {
       this.logger.info(`Collected ${points.length} ${queryType.toLowerCase()} episodes from Sonarr`);
     } catch (error) {
       this.logger.error(`Failed to collect Sonarr calendar (${queryType}): ${error}`);
+      throw error;
     }
 
     return points;

--- a/src/plugins/inputs/TautulliPlugin.ts
+++ b/src/plugins/inputs/TautulliPlugin.ts
@@ -161,6 +161,7 @@ export class TautulliPlugin extends BaseInputPlugin<TautulliConfig> {
       this.logger.info(`Collected ${sessions.length} sessions from Tautulli`);
     } catch (error) {
       this.logger.error(`Failed to collect Tautulli activity: ${error}`);
+      throw error; // Propagate error for circuit breaker
     }
 
     return points;
@@ -449,6 +450,7 @@ export class TautulliPlugin extends BaseInputPlugin<TautulliConfig> {
       this.logger.info(`Collected ${libraries.length} library stats from Tautulli`);
     } catch (error) {
       this.logger.error(`Failed to collect Tautulli libraries: ${error}`);
+      throw error; // Propagate error for circuit breaker
     }
 
     return points;

--- a/src/types/health.types.ts
+++ b/src/types/health.types.ts
@@ -8,6 +8,30 @@
 export type HealthStatus = 'healthy' | 'degraded' | 'unhealthy';
 
 /**
+ * Circuit breaker state
+ * - closed: Normal operation, requests are allowed
+ * - open: Circuit is tripped, requests are blocked
+ * - half-open: Testing if service has recovered
+ */
+export type CircuitBreakerState = 'closed' | 'open' | 'half-open';
+
+/**
+ * Circuit breaker configuration
+ */
+export interface CircuitBreakerConfig {
+  /** Number of consecutive errors before disabling scheduler (default: 10) */
+  maxConsecutiveErrors: number;
+  /** Interval multiplier per failure (default: 2) */
+  backoffMultiplier: number;
+  /** Maximum interval cap in seconds (default: 600) */
+  maxIntervalSeconds: number;
+  /** Wait time before recovery attempt in seconds (default: 300) */
+  cooldownSeconds: number;
+  /** Number of successes needed to fully recover (default: 3) */
+  recoverySuccesses: number;
+}
+
+/**
  * Public scheduler status for health checks
  */
 export interface SchedulerStatus {
@@ -18,6 +42,18 @@ export interface SchedulerStatus {
   lastRunAt?: Date;
   lastError?: string;
   consecutiveErrors: number;
+  /** Circuit breaker state */
+  circuitState: CircuitBreakerState;
+  /** Current interval in seconds (may differ from base due to backoff) */
+  currentIntervalSeconds: number;
+  /** When the circuit was opened (disabled) */
+  disabledAt?: Date;
+  /** When the next recovery attempt will be made (circuit open) */
+  nextAttemptAt?: Date;
+  /** Number of successful recoveries in half-open state */
+  recoverySuccesses: number;
+  /** When the next scheduled run will occur */
+  nextRunAt?: Date;
 }
 
 /**

--- a/tests/core/HealthServer.test.ts
+++ b/tests/core/HealthServer.test.ts
@@ -64,6 +64,9 @@ function createMockPluginManager(overrides: {
       isRunning: false,
       lastRunAt: new Date(),
       consecutiveErrors: 0,
+      circuitState: 'closed',
+      currentIntervalSeconds: 30,
+      recoverySuccesses: 0,
     },
   ];
   const defaultInputStatuses: PluginStatus[] = [
@@ -164,8 +167,8 @@ describe('HealthServer', () => {
     it('should return degraded status when some schedulers have errors', async () => {
       const mockPm = createMockPluginManager({
         schedulerStatuses: [
-          { name: 'sonarr_1_queue', pluginName: 'Sonarr', intervalSeconds: 30, isRunning: false, consecutiveErrors: 5 },
-          { name: 'radarr_1_queue', pluginName: 'Radarr', intervalSeconds: 30, isRunning: false, consecutiveErrors: 0 },
+          { name: 'sonarr_1_queue', pluginName: 'Sonarr', intervalSeconds: 30, isRunning: false, consecutiveErrors: 5, circuitState: 'closed', currentIntervalSeconds: 30, recoverySuccesses: 0 },
+          { name: 'radarr_1_queue', pluginName: 'Radarr', intervalSeconds: 30, isRunning: false, consecutiveErrors: 0, circuitState: 'closed', currentIntervalSeconds: 30, recoverySuccesses: 0 },
         ],
       });
       healthServer.setPluginManager(mockPm);
@@ -207,7 +210,7 @@ describe('HealthServer', () => {
       const mockPm = createMockPluginManager({
         healthCheck: new Map([['influxdb2', false]]),
         schedulerStatuses: [
-          { name: 'sonarr_1_queue', pluginName: 'Sonarr', intervalSeconds: 30, isRunning: false, consecutiveErrors: 5 },
+          { name: 'sonarr_1_queue', pluginName: 'Sonarr', intervalSeconds: 30, isRunning: false, consecutiveErrors: 5, circuitState: 'closed', currentIntervalSeconds: 30, recoverySuccesses: 0 },
         ],
       });
       healthServer.setPluginManager(mockPm);
@@ -306,6 +309,9 @@ describe('HealthServer', () => {
             lastRunAt: new Date(),
             lastError: 'Connection refused',
             consecutiveErrors: 3,
+            circuitState: 'closed',
+            currentIntervalSeconds: 30,
+            recoverySuccesses: 0,
           },
         ],
       });
@@ -363,6 +369,91 @@ describe('HealthServer', () => {
 
       expect(response.statusCode).toBe(405);
       expect(body.error).toBe('Method Not Allowed');
+    });
+  });
+
+  describe('circuit breaker status reporting', () => {
+    it('should return degraded status when some schedulers have open circuits', async () => {
+      const mockPm = createMockPluginManager({
+        schedulerStatuses: [
+          { name: 'sonarr_1_queue', pluginName: 'Sonarr', intervalSeconds: 30, isRunning: false, consecutiveErrors: 10, circuitState: 'open', currentIntervalSeconds: 30, recoverySuccesses: 0, disabledAt: new Date(), nextAttemptAt: new Date(Date.now() + 300000) },
+          { name: 'radarr_1_queue', pluginName: 'Radarr', intervalSeconds: 30, isRunning: false, consecutiveErrors: 0, circuitState: 'closed', currentIntervalSeconds: 30, recoverySuccesses: 0 },
+        ],
+      });
+      healthServer.setPluginManager(mockPm);
+      await healthServer.start();
+
+      const response = await httpGet(testPort, '/health');
+      const body = JSON.parse(response.body);
+
+      expect(response.statusCode).toBe(200);
+      expect(body.status).toBe('degraded');
+    });
+
+    it('should return unhealthy status when all schedulers have open circuits', async () => {
+      const mockPm = createMockPluginManager({
+        schedulerStatuses: [
+          { name: 'sonarr_1_queue', pluginName: 'Sonarr', intervalSeconds: 30, isRunning: false, consecutiveErrors: 10, circuitState: 'open', currentIntervalSeconds: 30, recoverySuccesses: 0, disabledAt: new Date(), nextAttemptAt: new Date(Date.now() + 300000) },
+          { name: 'radarr_1_queue', pluginName: 'Radarr', intervalSeconds: 30, isRunning: false, consecutiveErrors: 10, circuitState: 'open', currentIntervalSeconds: 30, recoverySuccesses: 0, disabledAt: new Date(), nextAttemptAt: new Date(Date.now() + 300000) },
+        ],
+      });
+      healthServer.setPluginManager(mockPm);
+      await healthServer.start();
+
+      const response = await httpGet(testPort, '/health');
+      const body = JSON.parse(response.body);
+
+      expect(response.statusCode).toBe(503);
+      expect(body.status).toBe('unhealthy');
+    });
+
+    it('should return degraded status when scheduler is in half-open state (recovering)', async () => {
+      const mockPm = createMockPluginManager({
+        schedulerStatuses: [
+          { name: 'sonarr_1_queue', pluginName: 'Sonarr', intervalSeconds: 30, isRunning: false, consecutiveErrors: 0, circuitState: 'half-open', currentIntervalSeconds: 30, recoverySuccesses: 1 },
+        ],
+      });
+      healthServer.setPluginManager(mockPm);
+      await healthServer.start();
+
+      const response = await httpGet(testPort, '/health');
+      const body = JSON.parse(response.body);
+
+      // Half-open means still recovering, not fully healthy
+      expect(response.statusCode).toBe(200);
+      expect(body.status).toBe('degraded');
+    });
+
+    it('should include circuit breaker fields in status response', async () => {
+      const disabledAt = new Date();
+      const nextAttemptAt = new Date(Date.now() + 300000);
+      const mockPm = createMockPluginManager({
+        schedulerStatuses: [
+          {
+            name: 'sonarr_1_queue',
+            pluginName: 'Sonarr',
+            intervalSeconds: 30,
+            isRunning: false,
+            consecutiveErrors: 10,
+            circuitState: 'open',
+            currentIntervalSeconds: 120,
+            recoverySuccesses: 0,
+            disabledAt,
+            nextAttemptAt,
+          },
+        ],
+      });
+      healthServer.setPluginManager(mockPm);
+      await healthServer.start();
+
+      const response = await httpGet(testPort, '/status');
+      const body = JSON.parse(response.body);
+
+      expect(body.schedulers[0].circuitState).toBe('open');
+      expect(body.schedulers[0].currentIntervalSeconds).toBe(120);
+      expect(body.schedulers[0].recoverySuccesses).toBe(0);
+      expect(body.schedulers[0].disabledAt).toBeDefined();
+      expect(body.schedulers[0].nextAttemptAt).toBeDefined();
     });
   });
 

--- a/tests/core/PluginManager.test.ts
+++ b/tests/core/PluginManager.test.ts
@@ -677,14 +677,15 @@ describe('PluginManager', () => {
       await pluginManager.initializeFromConfig(minimalConfig);
       await pluginManager.startSchedulers();
 
-      // First execution fails
-      await vi.advanceTimersByTimeAsync(1100);
+      // First execution fails (immediate run on start)
+      await vi.advanceTimersByTimeAsync(100);
       let statuses = pluginManager.getSchedulerStatuses();
       expect(statuses[0].consecutiveErrors).toBeGreaterThan(0);
 
       // Now make it succeed
       shouldFail = false;
-      await vi.advanceTimersByTimeAsync(1000);
+      // Wait for next scheduled run (with backoff, interval is now 2s)
+      await vi.advanceTimersByTimeAsync(2100);
       statuses = pluginManager.getSchedulerStatuses();
       expect(statuses[0].consecutiveErrors).toBe(0);
       expect(statuses[0].lastError).toBeUndefined();
@@ -708,6 +709,327 @@ describe('PluginManager', () => {
 
       const stats = pluginManager.getStats();
       expect(stats.activeSchedulers).toBe(0);
+    });
+  });
+
+  describe('circuit breaker', () => {
+    it('should apply backoff on consecutive errors', async () => {
+      class FailingPlugin extends MockInputPlugin {
+        async collect(): Promise<DataPoint[]> {
+          throw new Error('Always fails');
+        }
+      }
+
+      pluginManager.registerInputPlugin('sonarr', FailingPlugin);
+      pluginManager.registerOutputPlugin('influxdb1', MockOutputPlugin);
+      await pluginManager.initializeFromConfig(minimalConfig);
+      await pluginManager.startSchedulers();
+
+      // Initial run fails, backoff applied (interval doubles from 1s to 2s)
+      await vi.advanceTimersByTimeAsync(100);
+      let statuses = pluginManager.getSchedulerStatuses();
+      expect(statuses[0].consecutiveErrors).toBe(1);
+      expect(statuses[0].currentIntervalSeconds).toBe(2); // 1s * 2 = 2s
+
+      // Wait for second execution (2s interval)
+      await vi.advanceTimersByTimeAsync(2100);
+      statuses = pluginManager.getSchedulerStatuses();
+      expect(statuses[0].consecutiveErrors).toBe(2);
+      expect(statuses[0].currentIntervalSeconds).toBe(4); // 2s * 2 = 4s
+    });
+
+    it('should cap backoff at maxIntervalSeconds', async () => {
+      class FailingPlugin extends MockInputPlugin {
+        async collect(): Promise<DataPoint[]> {
+          throw new Error('Always fails');
+        }
+      }
+
+      // Configure with very low max interval for testing
+      const configWithCircuitBreaker = {
+        ...minimalConfig,
+        circuitBreaker: {
+          maxConsecutiveErrors: 10,
+          backoffMultiplier: 2,
+          maxIntervalSeconds: 4, // Cap at 4 seconds
+          cooldownSeconds: 300,
+          recoverySuccesses: 3,
+        },
+      };
+
+      pluginManager.registerInputPlugin('sonarr', FailingPlugin);
+      pluginManager.registerOutputPlugin('influxdb1', MockOutputPlugin);
+      await pluginManager.initializeFromConfig(configWithCircuitBreaker);
+      await pluginManager.startSchedulers();
+
+      // First failure: 1s * 2 = 2s
+      await vi.advanceTimersByTimeAsync(100);
+      let statuses = pluginManager.getSchedulerStatuses();
+      expect(statuses[0].currentIntervalSeconds).toBe(2);
+
+      // Second failure: 2s * 2 = 4s (at cap)
+      await vi.advanceTimersByTimeAsync(2100);
+      statuses = pluginManager.getSchedulerStatuses();
+      expect(statuses[0].currentIntervalSeconds).toBe(4);
+
+      // Third failure: should stay at 4s (capped)
+      await vi.advanceTimersByTimeAsync(4100);
+      statuses = pluginManager.getSchedulerStatuses();
+      expect(statuses[0].currentIntervalSeconds).toBe(4);
+    });
+
+    it('should open circuit after maxConsecutiveErrors', async () => {
+      class FailingPlugin extends MockInputPlugin {
+        async collect(): Promise<DataPoint[]> {
+          throw new Error('Always fails');
+        }
+      }
+
+      // Configure with low maxConsecutiveErrors for testing
+      const configWithCircuitBreaker = {
+        ...minimalConfig,
+        circuitBreaker: {
+          maxConsecutiveErrors: 3,
+          backoffMultiplier: 1, // No backoff for simpler test timing
+          maxIntervalSeconds: 600,
+          cooldownSeconds: 60,
+          recoverySuccesses: 3,
+        },
+      };
+
+      pluginManager.registerInputPlugin('sonarr', FailingPlugin);
+      pluginManager.registerOutputPlugin('influxdb1', MockOutputPlugin);
+      await pluginManager.initializeFromConfig(configWithCircuitBreaker);
+      await pluginManager.startSchedulers();
+
+      // Three failures (immediate + 2 intervals)
+      await vi.advanceTimersByTimeAsync(100); // First execution
+      await vi.advanceTimersByTimeAsync(1100); // Second
+      await vi.advanceTimersByTimeAsync(1100); // Third
+
+      const statuses = pluginManager.getSchedulerStatuses();
+      expect(statuses[0].circuitState).toBe('open');
+      expect(statuses[0].consecutiveErrors).toBe(3);
+      expect(statuses[0].disabledAt).toBeDefined();
+      expect(statuses[0].nextAttemptAt).toBeDefined();
+    });
+
+    it('should skip execution when circuit is open', async () => {
+      let callCount = 0;
+      class CountingFailingPlugin extends MockInputPlugin {
+        async collect(): Promise<DataPoint[]> {
+          callCount++;
+          throw new Error('Always fails');
+        }
+      }
+
+      const configWithCircuitBreaker = {
+        ...minimalConfig,
+        circuitBreaker: {
+          maxConsecutiveErrors: 2,
+          backoffMultiplier: 1,
+          maxIntervalSeconds: 600,
+          cooldownSeconds: 60,
+          recoverySuccesses: 3,
+        },
+      };
+
+      pluginManager.registerInputPlugin('sonarr', CountingFailingPlugin);
+      pluginManager.registerOutputPlugin('influxdb1', MockOutputPlugin);
+      await pluginManager.initializeFromConfig(configWithCircuitBreaker);
+      await pluginManager.startSchedulers();
+
+      // Two failures to open circuit
+      await vi.advanceTimersByTimeAsync(100);
+      await vi.advanceTimersByTimeAsync(1100);
+
+      const callsBeforeOpen = callCount;
+      expect(callsBeforeOpen).toBe(2);
+
+      // Circuit should be open, further executions should be skipped
+      await vi.advanceTimersByTimeAsync(1100);
+      await vi.advanceTimersByTimeAsync(1100);
+
+      // Call count should not increase while circuit is open
+      expect(callCount).toBe(callsBeforeOpen);
+    });
+
+    it('should transition to half-open after cooldown', async () => {
+      class FailingPlugin extends MockInputPlugin {
+        async collect(): Promise<DataPoint[]> {
+          throw new Error('Always fails');
+        }
+      }
+
+      const configWithCircuitBreaker = {
+        ...minimalConfig,
+        circuitBreaker: {
+          maxConsecutiveErrors: 2,
+          backoffMultiplier: 1,
+          maxIntervalSeconds: 600,
+          cooldownSeconds: 5, // Short cooldown for testing
+          recoverySuccesses: 3,
+        },
+      };
+
+      pluginManager.registerInputPlugin('sonarr', FailingPlugin);
+      pluginManager.registerOutputPlugin('influxdb1', MockOutputPlugin);
+      await pluginManager.initializeFromConfig(configWithCircuitBreaker);
+      await pluginManager.startSchedulers();
+
+      // Open the circuit
+      await vi.advanceTimersByTimeAsync(100);
+      await vi.advanceTimersByTimeAsync(1100);
+
+      let statuses = pluginManager.getSchedulerStatuses();
+      expect(statuses[0].circuitState).toBe('open');
+
+      // Wait for cooldown (5 seconds) + next execution
+      await vi.advanceTimersByTimeAsync(6100);
+
+      statuses = pluginManager.getSchedulerStatuses();
+      // Circuit should transition to half-open, then back to open due to failure
+      expect(statuses[0].circuitState).toBe('open');
+    });
+
+    it('should close circuit after recoverySuccesses in half-open state', async () => {
+      let shouldFail = true;
+
+      class RecoverablePlugin extends MockInputPlugin {
+        async collect(): Promise<DataPoint[]> {
+          if (shouldFail) {
+            throw new Error('Temporary failure');
+          }
+          return [];
+        }
+      }
+
+      const configWithCircuitBreaker = {
+        ...minimalConfig,
+        circuitBreaker: {
+          maxConsecutiveErrors: 2,
+          backoffMultiplier: 1,
+          maxIntervalSeconds: 600,
+          cooldownSeconds: 5, // Longer cooldown
+          recoverySuccesses: 3, // Need 3 successes to recover
+        },
+      };
+
+      pluginManager.registerInputPlugin('sonarr', RecoverablePlugin);
+      pluginManager.registerOutputPlugin('influxdb1', MockOutputPlugin);
+      await pluginManager.initializeFromConfig(configWithCircuitBreaker);
+      await pluginManager.startSchedulers();
+
+      // Open the circuit with 2 failures (immediate run + first interval)
+      await vi.advanceTimersByTimeAsync(100);
+      await vi.advanceTimersByTimeAsync(1100);
+
+      let statuses = pluginManager.getSchedulerStatuses();
+      expect(statuses[0].circuitState).toBe('open');
+
+      // Now make it succeed
+      shouldFail = false;
+
+      // Wait for cooldown (5s) + first execution
+      await vi.advanceTimersByTimeAsync(5100);
+
+      statuses = pluginManager.getSchedulerStatuses();
+      expect(statuses[0].circuitState).toBe('half-open');
+      expect(statuses[0].recoverySuccesses).toBe(1);
+
+      // Second recovery success
+      await vi.advanceTimersByTimeAsync(1100);
+
+      statuses = pluginManager.getSchedulerStatuses();
+      expect(statuses[0].circuitState).toBe('half-open');
+      expect(statuses[0].recoverySuccesses).toBe(2);
+
+      // Third recovery success - should close the circuit
+      await vi.advanceTimersByTimeAsync(1100);
+
+      statuses = pluginManager.getSchedulerStatuses();
+      expect(statuses[0].circuitState).toBe('closed');
+      expect(statuses[0].consecutiveErrors).toBe(0);
+      expect(statuses[0].recoverySuccesses).toBe(0);
+    });
+
+    it('should return to open state on failure in half-open', async () => {
+      let failCount = 0;
+      const maxFailures = 3; // Fail first 3 times (2 to open + 1 recovery fail)
+
+      class SometimesRecoverablePlugin extends MockInputPlugin {
+        async collect(): Promise<DataPoint[]> {
+          failCount++;
+          if (failCount <= maxFailures) {
+            throw new Error('Failure');
+          }
+          return [];
+        }
+      }
+
+      const configWithCircuitBreaker = {
+        ...minimalConfig,
+        circuitBreaker: {
+          maxConsecutiveErrors: 2,
+          backoffMultiplier: 1,
+          maxIntervalSeconds: 600,
+          cooldownSeconds: 2,
+          recoverySuccesses: 3,
+        },
+      };
+
+      pluginManager.registerInputPlugin('sonarr', SometimesRecoverablePlugin);
+      pluginManager.registerOutputPlugin('influxdb1', MockOutputPlugin);
+      await pluginManager.initializeFromConfig(configWithCircuitBreaker);
+      await pluginManager.startSchedulers();
+
+      // Open the circuit with 2 failures
+      await vi.advanceTimersByTimeAsync(100);
+      await vi.advanceTimersByTimeAsync(1100);
+
+      let statuses = pluginManager.getSchedulerStatuses();
+      expect(statuses[0].circuitState).toBe('open');
+
+      // Wait for cooldown, then fail recovery
+      await vi.advanceTimersByTimeAsync(3100);
+
+      statuses = pluginManager.getSchedulerStatuses();
+      // Should be back to open after failed recovery
+      expect(statuses[0].circuitState).toBe('open');
+    });
+
+    it('should include circuit breaker fields in scheduler statuses', async () => {
+      pluginManager.registerInputPlugin('sonarr', MockInputPlugin);
+      pluginManager.registerOutputPlugin('influxdb1', MockOutputPlugin);
+      await pluginManager.initializeFromConfig(minimalConfig);
+      await pluginManager.startSchedulers();
+
+      const statuses = pluginManager.getSchedulerStatuses();
+
+      expect(statuses[0]).toHaveProperty('circuitState');
+      expect(statuses[0]).toHaveProperty('currentIntervalSeconds');
+      expect(statuses[0]).toHaveProperty('recoverySuccesses');
+      expect(statuses[0].circuitState).toBe('closed');
+      expect(statuses[0].currentIntervalSeconds).toBe(1);
+      expect(statuses[0].recoverySuccesses).toBe(0);
+    });
+
+    it('should use default circuit breaker config when not specified', async () => {
+      class FailingPlugin extends MockInputPlugin {
+        async collect(): Promise<DataPoint[]> {
+          throw new Error('Always fails');
+        }
+      }
+
+      pluginManager.registerInputPlugin('sonarr', FailingPlugin);
+      pluginManager.registerOutputPlugin('influxdb1', MockOutputPlugin);
+      await pluginManager.initializeFromConfig(minimalConfig);
+      await pluginManager.startSchedulers();
+
+      // With default config: backoffMultiplier=2
+      await vi.advanceTimersByTimeAsync(100);
+      const statuses = pluginManager.getSchedulerStatuses();
+      expect(statuses[0].currentIntervalSeconds).toBe(2); // 1s * 2
     });
   });
 

--- a/tests/plugins/inputs/BazarrPlugin.test.ts
+++ b/tests/plugins/inputs/BazarrPlugin.test.ts
@@ -319,25 +319,20 @@ describe('BazarrPlugin', () => {
       expect(points).toEqual([]);
     });
 
-    it('should handle wanted API errors gracefully', async () => {
+    it('should propagate wanted API errors for circuit breaker', async () => {
       mockHttpClient.get.mockRejectedValueOnce(new Error('Wanted API Error'));
-      // History calls
-      mockHttpClient.get.mockResolvedValueOnce({ data: { data: [], total: 0 } });
-      mockHttpClient.get.mockResolvedValueOnce({ data: { data: [], total: 0 } });
 
-      const points = await plugin.collect();
-      expect(points).toBeDefined();
+      await expect(plugin.collect()).rejects.toThrow('Wanted API Error');
     });
 
-    it('should handle history API errors gracefully', async () => {
-      // Wanted calls
+    it('should propagate history API errors for circuit breaker', async () => {
+      // Wanted calls succeed
       mockHttpClient.get.mockResolvedValueOnce({ data: { data: [], total: 0 } });
       mockHttpClient.get.mockResolvedValueOnce({ data: { data: [], total: 0 } });
       // History error
       mockHttpClient.get.mockRejectedValueOnce(new Error('History API Error'));
 
-      const points = await plugin.collect();
-      expect(points).toBeDefined();
+      await expect(plugin.collect()).rejects.toThrow('History API Error');
     });
 
     it('should generate deterministic hash IDs', async () => {

--- a/tests/plugins/inputs/LidarrPlugin.test.ts
+++ b/tests/plugins/inputs/LidarrPlugin.test.ts
@@ -309,23 +309,19 @@ describe('LidarrPlugin', () => {
       expect(points).toEqual([]);
     });
 
-    it('should handle queue API errors gracefully', async () => {
+    it('should propagate queue API errors for circuit breaker', async () => {
       mockHttpClient.get.mockRejectedValueOnce(new Error('Queue API Error'));
-      mockHttpClient.get.mockResolvedValueOnce({ data: { records: [] } });
 
-      const points = await plugin.collect();
-      expect(points).toBeDefined();
+      await expect(plugin.collect()).rejects.toThrow('Queue API Error');
     });
 
-    it('should handle missing albums API errors gracefully', async () => {
+    it('should propagate missing albums API errors for circuit breaker', async () => {
       mockHttpClient.get.mockResolvedValueOnce({
         data: { totalRecords: 0, records: [] },
       });
       mockHttpClient.get.mockRejectedValueOnce(new Error('Missing API Error'));
 
-      const points = await plugin.collect();
-      expect(points).toBeDefined();
-      expect(points).toEqual([]);
+      await expect(plugin.collect()).rejects.toThrow('Missing API Error');
     });
 
     it('should skip queue items without album data', async () => {

--- a/tests/plugins/inputs/OmbiPlugin.test.ts
+++ b/tests/plugins/inputs/OmbiPlugin.test.ts
@@ -412,14 +412,11 @@ describe('OmbiPlugin', () => {
       expect(requestPoints).toHaveLength(0);
     });
 
-    it('should handle API errors gracefully', async () => {
+    it('should propagate API errors for circuit breaker', async () => {
       const httpGetSpy = vi.spyOn(plugin as unknown as { httpGet: <T>(path: string) => Promise<T> }, 'httpGet');
       httpGetSpy.mockRejectedValue(new Error('API Error'));
 
-      const points = await plugin.collect();
-
-      // Should return empty array without throwing
-      expect(points).toEqual([]);
+      await expect(plugin.collect()).rejects.toThrow('API Error');
     });
 
     it('should resolve userName from Identity API when alias is missing', async () => {

--- a/tests/plugins/inputs/OverseerrPlugin.test.ts
+++ b/tests/plugins/inputs/OverseerrPlugin.test.ts
@@ -377,14 +377,10 @@ describe('OverseerrPlugin', () => {
       expect(points.filter((p) => p.tags.type === 'Requests').length).toBe(0);
     });
 
-    it('should handle API errors gracefully', async () => {
+    it('should propagate API errors for circuit breaker', async () => {
       mockHttpClient.get.mockRejectedValueOnce(new Error('Request counts API error'));
-      mockHttpClient.get.mockRejectedValueOnce(new Error('Issue counts API error'));
-      mockHttpClient.get.mockRejectedValueOnce(new Error('Latest requests API error'));
 
-      const points = await plugin.collect();
-      expect(points).toBeDefined();
-      expect(points.length).toBe(0);
+      await expect(plugin.collect()).rejects.toThrow('Request counts API error');
     });
 
     it('should handle media details fetch failure gracefully', async () => {

--- a/tests/plugins/inputs/ProwlarrPlugin.test.ts
+++ b/tests/plugins/inputs/ProwlarrPlugin.test.ts
@@ -201,12 +201,10 @@ describe('ProwlarrPlugin', () => {
       expect(points).toEqual([]);
     });
 
-    it('should handle API errors gracefully', async () => {
+    it('should propagate API errors for circuit breaker', async () => {
       mockHttpClient.get.mockRejectedValueOnce(new Error('API Error'));
 
-      const points = await plugin.collect();
-      expect(points).toBeDefined();
-      expect(points).toEqual([]);
+      await expect(plugin.collect()).rejects.toThrow('API Error');
     });
 
     it('should generate deterministic hash IDs', async () => {

--- a/tests/plugins/inputs/RadarrPlugin.test.ts
+++ b/tests/plugins/inputs/RadarrPlugin.test.ts
@@ -301,12 +301,10 @@ describe('RadarrPlugin', () => {
       expect(points).toEqual([]);
     });
 
-    it('should handle API errors gracefully', async () => {
+    it('should propagate API errors for circuit breaker', async () => {
       mockHttpClient.get.mockRejectedValueOnce(new Error('API Error'));
-      mockHttpClient.get.mockResolvedValueOnce({ data: [] });
 
-      const points = await plugin.collect();
-      expect(points).toBeDefined();
+      await expect(plugin.collect()).rejects.toThrow('API Error');
     });
 
     it('should skip queue items without movie data', async () => {

--- a/tests/plugins/inputs/ReadarrPlugin.test.ts
+++ b/tests/plugins/inputs/ReadarrPlugin.test.ts
@@ -302,12 +302,10 @@ describe('ReadarrPlugin', () => {
       expect(points).toEqual([]);
     });
 
-    it('should handle API errors gracefully', async () => {
+    it('should propagate API errors for circuit breaker', async () => {
       mockHttpClient.get.mockRejectedValueOnce(new Error('API Error'));
-      mockHttpClient.get.mockResolvedValueOnce({ data: [] });
 
-      const points = await plugin.collect();
-      expect(points).toBeDefined();
+      await expect(plugin.collect()).rejects.toThrow('API Error');
     });
 
     it('should skip queue items without book data', async () => {

--- a/tests/plugins/inputs/SonarrPlugin.test.ts
+++ b/tests/plugins/inputs/SonarrPlugin.test.ts
@@ -272,13 +272,10 @@ describe('SonarrPlugin', () => {
       expect(points).toEqual([]);
     });
 
-    it('should handle API errors gracefully', async () => {
+    it('should propagate API errors for circuit breaker', async () => {
       mockHttpClient.get.mockRejectedValueOnce(new Error('API Error'));
-      mockHttpClient.get.mockResolvedValueOnce({ data: [] });
-      mockHttpClient.get.mockResolvedValueOnce({ data: [] });
 
-      const points = await plugin.collect();
-      expect(points).toBeDefined();
+      await expect(plugin.collect()).rejects.toThrow('API Error');
     });
 
     it('should paginate through large queues', async () => {

--- a/tests/plugins/inputs/TautulliPlugin.test.ts
+++ b/tests/plugins/inputs/TautulliPlugin.test.ts
@@ -768,13 +768,10 @@ describe('TautulliPlugin', () => {
       expect(musicLib?.fields.tracks).toBe(10000);
     });
 
-    it('should handle API errors gracefully', async () => {
-      mockHttpClient.get.mockRejectedValueOnce(new Error('API Error'));
+    it('should propagate API errors for circuit breaker', async () => {
       mockHttpClient.get.mockRejectedValueOnce(new Error('API Error'));
 
-      const points = await plugin.collect();
-      expect(points).toBeDefined();
-      expect(points.length).toBe(0);
+      await expect(plugin.collect()).rejects.toThrow('API Error');
     });
 
     it('should handle invalid API responses', async () => {


### PR DESCRIPTION
## Description

Implement full circuit breaker state machine (closed → open → half-open) with:
- Exponential backoff on errors (configurable multiplier and max interval)
- Auto-disable failing schedulers after configurable consecutive errors
- Cooldown period before recovery attempts
- Gradual recovery via half-open state with configurable success threshold
- `nextRunAt` field in scheduler status for monitoring

### Changes
- **PluginManager**: Refactored from `setInterval` to `setTimeout` chaining, added circuit breaker state machine
- **HealthServer**: Updated status calculation to consider circuit states
- **Config**: Added optional `circuitBreaker` section with Zod schema
- **Plugins**: All input plugins now propagate errors for circuit breaker tracking
- **Types**: Added `CircuitBreakerState`, `CircuitBreakerConfig`, updated `SchedulerStatus`
- **Docs**: README, PLAN.md, varken.example.yaml, .claude/project.md updated

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation
- [x] Refactoring
- [ ] Dependencies update

## Checklist
- [x] I have tested my changes locally
- [x] I have added/updated tests if needed
- [x] Code coverage is maintained or improved
- [x] Lint passes (`npm run lint`)
- [x] Tests pass (`npm test`)

## Related Issues