### PR TITLE
feat(outputs): add VictoriaMetrics output plugin

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -272,11 +272,10 @@ interface ScheduleConfig {
 
 ### Phase 8: Additional Output Plugins
 
-#### VictoriaMetrics (High Priority)
-- [ ] `VictoriaMetricsPlugin` - InfluxDB line protocol compatible
+#### VictoriaMetrics ✅
+- [x] `VictoriaMetricsPlugin` - InfluxDB line protocol compatible
   - Reuses existing Line Protocol code from BaseOutputPlugin
   - Uses `axios` (already installed)
-  - Effort: ~4h
 
 #### QuestDB
 - [ ] `QuestDBPlugin` - InfluxDB line protocol (ILP) support
@@ -500,7 +499,7 @@ interface ScheduleConfig {
 |--------|----------|-------------|--------|
 | **InfluxDB1Plugin** | HTTP API v1 | InfluxDB 1.x - Legacy, InfluxQL | ✅ |
 | **InfluxDB2Plugin** | HTTP API v2 | InfluxDB 2.x - Flux, Buckets, Tokens | ✅ |
-| **VictoriaMetricsPlugin** | InfluxDB line protocol | High performance, compatible | 🚧 Types ready |
+| **VictoriaMetricsPlugin** | InfluxDB line protocol | High performance, compatible | ✅ |
 | **QuestDBPlugin** | ILP over TCP/HTTP | Time-series SQL, fast ingestion | 🚧 Types ready |
 | **TimescaleDBPlugin** | PostgreSQL | Hypertables, standard SQL | 🚧 Types ready |
 
@@ -526,7 +525,7 @@ DataPoint (internal format)
 |------|--------|--------|
 | ~~Health endpoint~~ | ~~✅~~ | ~~Production readiness~~ |
 | ~~Circuit breaker~~ | ~~✅~~ | ~~Error tracking, auto-disable, scheduler backoff~~ |
-| VictoriaMetrics output | ~4h | Popular alternative DB |
+| ~~VictoriaMetrics output~~ | ~~✅~~ | ~~Popular alternative DB~~ |
 | ~~Test Logger (42% → 84%)~~ | ~~✅~~ | ~~Critical coverage gap~~ |
 | ~~Test entry point (0% → 100%)~~ | ~~✅~~ | ~~Coverage~~ |
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Built with TypeScript, Node.js, and a plugin-based architecture with scheduled d
 ### Data Collection
 
 - **Multiple data sources** — Sonarr, Radarr, Readarr, Lidarr, Tautulli, Ombi, Overseerr, Prowlarr, Bazarr
-- **Multiple outputs** — InfluxDB 1.x and InfluxDB 2.x
+- **Multiple outputs** — InfluxDB 1.x, InfluxDB 2.x, VictoriaMetrics
 - **Multi-instance support** — connect multiple instances of each service
 - **GeoIP mapping** — automatic geolocation of streaming sessions via Tautulli API (no external license required)
 
@@ -77,10 +77,13 @@ Built with TypeScript, Node.js, and a plugin-based architecture with scheduled d
 
 ### Output Plugins
 
-| Output                         | Status |
-|--------------------------------|--------|
-| **InfluxDB 2.x** (recommended) | ✅      |
-| **InfluxDB 1.x** (legacy)      | ✅      |
+| Output                         | Status     |
+|--------------------------------|------------|
+| **InfluxDB 2.x** (recommended) | ✅          |
+| **InfluxDB 1.x** (legacy)      | ✅          |
+| **VictoriaMetrics**            | ✅          |
+| **QuestDB**                    | 🚧 Planned |
+| **TimescaleDB**                | 🚧 Planned |
 
 ## Installation
 
@@ -158,6 +161,33 @@ inputs:
         enabled: true
         intervalSeconds: 30
 ```
+
+### Output Configuration
+
+Varken supports multiple output backends. You can configure one or several simultaneously — each data point is written to every configured output.
+
+```yaml
+outputs:
+  # InfluxDB 2.x (recommended)
+  influxdb2:
+    url: "http://influxdb:8086"
+    token: "your-token"
+    org: "varken"
+    bucket: "varken"
+
+  # InfluxDB 1.x (legacy)
+  influxdb1:
+    url: "http://influxdb:8086"
+    username: "root"
+    password: "root"
+    database: "varken"
+
+  # VictoriaMetrics (InfluxDB line protocol compatible)
+  victoriametrics:
+    url: "http://victoriametrics:8428"
+```
+
+See [`config/varken.example.yaml`](config/varken.example.yaml) for the complete list of supported options.
 
 ### Global Settings
 

--- a/src/plugins/outputs/VictoriaMetricsPlugin.ts
+++ b/src/plugins/outputs/VictoriaMetricsPlugin.ts
@@ -1,0 +1,66 @@
+import type { AxiosInstance } from 'axios';
+import type { z } from 'zod';
+import { BaseOutputPlugin } from './BaseOutputPlugin';
+import type { DataPoint, PluginMetadata } from '../../types/plugin.types';
+import type { VictoriaMetricsConfigSchema } from '../../config/schemas/config.schema';
+import { createHttpClient, formatHttpError, withTimeout } from '../../utils/http';
+
+export type VictoriaMetricsConfig = z.infer<typeof VictoriaMetricsConfigSchema>;
+
+/**
+ * VictoriaMetrics output plugin
+ * Writes data using InfluxDB line protocol over HTTP.
+ */
+export class VictoriaMetricsPlugin extends BaseOutputPlugin<VictoriaMetricsConfig> {
+  readonly metadata: PluginMetadata = {
+    name: 'VictoriaMetrics',
+    version: '1.0.0',
+    description: 'VictoriaMetrics output plugin using InfluxDB line protocol',
+  };
+
+  private client!: AxiosInstance;
+
+  async initialize(config: VictoriaMetricsConfig): Promise<void> {
+    await super.initialize(config);
+
+    const baseURL = this.getBaseUrl();
+
+    this.client = createHttpClient({
+      baseURL,
+      verifySsl: this.config.verifySsl,
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    });
+
+    this.logger.info(`Connected to VictoriaMetrics at ${baseURL}`);
+  }
+
+  async write(points: DataPoint[]): Promise<void> {
+    if (points.length === 0) {
+      return;
+    }
+
+    const body = this.toLineProtocolBatch(points);
+
+    try {
+      await withTimeout(
+        this.client.post('/write', body),
+        30000,
+        'VictoriaMetrics write timed out after 30000ms'
+      );
+      this.logger.debug(`Wrote ${points.length} points to VictoriaMetrics`);
+    } catch (error) {
+      this.logger.error(`Failed to write to VictoriaMetrics: ${formatHttpError(error)}`);
+      throw error;
+    }
+  }
+
+  async healthCheck(): Promise<boolean> {
+    try {
+      const response = await this.client.get('/health');
+      return response.status === 200;
+    } catch (error) {
+      this.logger.debug(`VictoriaMetrics health check failed: ${formatHttpError(error)}`);
+      return false;
+    }
+  }
+}

--- a/src/plugins/outputs/index.ts
+++ b/src/plugins/outputs/index.ts
@@ -3,11 +3,13 @@ import type { OutputPluginFactory } from '../../core/PluginManager';
 // Plugin imports
 import { InfluxDB1Plugin } from './InfluxDB1Plugin';
 import { InfluxDB2Plugin } from './InfluxDB2Plugin';
+import { VictoriaMetricsPlugin } from './VictoriaMetricsPlugin';
 
 // Re-exports for direct usage
 export { BaseOutputPlugin, BaseOutputConfig } from './BaseOutputPlugin';
 export { InfluxDB1Plugin, InfluxDB1Config } from './InfluxDB1Plugin';
 export { InfluxDB2Plugin, InfluxDB2Config } from './InfluxDB2Plugin';
+export { VictoriaMetricsPlugin, VictoriaMetricsConfig } from './VictoriaMetricsPlugin';
 
 /**
  * All available output plugin classes
@@ -16,6 +18,7 @@ export { InfluxDB2Plugin, InfluxDB2Config } from './InfluxDB2Plugin';
 const outputPluginClasses: OutputPluginFactory[] = [
   InfluxDB1Plugin,
   InfluxDB2Plugin,
+  VictoriaMetricsPlugin,
 ];
 
 /**

--- a/tests/plugins/outputs/VictoriaMetricsPlugin.test.ts
+++ b/tests/plugins/outputs/VictoriaMetricsPlugin.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { VictoriaMetricsPlugin } from '../../../src/plugins/outputs/VictoriaMetricsPlugin';
+import type { DataPoint } from '../../../src/types/plugin.types';
+
+vi.mock('../../../src/core/Logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+const mockPost = vi.fn().mockResolvedValue({ status: 204 });
+const mockGet = vi.fn().mockResolvedValue({ status: 200 });
+
+vi.mock('../../../src/utils/http', async () => {
+  const actual = await vi.importActual<typeof import('../../../src/utils/http')>(
+    '../../../src/utils/http'
+  );
+  return {
+    ...actual,
+    createHttpClient: vi.fn(() => ({
+      post: mockPost,
+      get: mockGet,
+    })),
+  };
+});
+
+describe('VictoriaMetricsPlugin', () => {
+  let plugin: VictoriaMetricsPlugin;
+  const testConfig = {
+    url: 'localhost',
+    port: 8428,
+    ssl: false,
+    verifySsl: false,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPost.mockResolvedValue({ status: 204 });
+    mockGet.mockResolvedValue({ status: 200 });
+    plugin = new VictoriaMetricsPlugin();
+  });
+
+  describe('metadata', () => {
+    it('should have correct metadata', () => {
+      expect(plugin.metadata.name).toBe('VictoriaMetrics');
+      expect(plugin.metadata.version).toBe('1.0.0');
+      expect(plugin.metadata.description).toContain('VictoriaMetrics');
+    });
+  });
+
+  describe('initialize', () => {
+    it('should initialize successfully with plain config', async () => {
+      await expect(plugin.initialize(testConfig)).resolves.toBeUndefined();
+    });
+
+    it('should initialize with SSL enabled', async () => {
+      await expect(
+        plugin.initialize({ ...testConfig, ssl: true, verifySsl: true })
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('write', () => {
+    beforeEach(async () => {
+      await plugin.initialize(testConfig);
+    });
+
+    it('should POST line protocol payload for a single point', async () => {
+      const points: DataPoint[] = [
+        {
+          measurement: 'test_measurement',
+          tags: { host: 'server1' },
+          fields: { value: 42 },
+          timestamp: new Date('2026-01-01T00:00:00Z'),
+        },
+      ];
+
+      await plugin.write(points);
+
+      expect(mockPost).toHaveBeenCalledTimes(1);
+      const [path, body] = mockPost.mock.calls[0];
+      expect(path).toBe('/write');
+      expect(body).toContain('test_measurement');
+      expect(body).toContain('host=server1');
+      expect(body).toContain('value=42i');
+    });
+
+    it('should batch multiple points in a single request', async () => {
+      const points: DataPoint[] = [
+        { measurement: 'm1', tags: {}, fields: { v: 1 }, timestamp: new Date() },
+        { measurement: 'm2', tags: {}, fields: { v: 2 }, timestamp: new Date() },
+      ];
+
+      await plugin.write(points);
+
+      expect(mockPost).toHaveBeenCalledTimes(1);
+      const [, body] = mockPost.mock.calls[0];
+      expect((body as string).split('\n')).toHaveLength(2);
+    });
+
+    it('should skip write when no points are provided', async () => {
+      await plugin.write([]);
+      expect(mockPost).not.toHaveBeenCalled();
+    });
+
+    it('should propagate write errors', async () => {
+      mockPost.mockRejectedValueOnce(new Error('connection refused'));
+      const points: DataPoint[] = [
+        { measurement: 'm', tags: {}, fields: { v: 1 }, timestamp: new Date() },
+      ];
+
+      await expect(plugin.write(points)).rejects.toThrow('connection refused');
+    });
+  });
+
+  describe('healthCheck', () => {
+    beforeEach(async () => {
+      await plugin.initialize(testConfig);
+    });
+
+    it('should return true when /health returns 200', async () => {
+      mockGet.mockResolvedValueOnce({ status: 200 });
+      await expect(plugin.healthCheck()).resolves.toBe(true);
+    });
+
+    it('should return false when /health returns non-200', async () => {
+      mockGet.mockResolvedValueOnce({ status: 503 });
+      await expect(plugin.healthCheck()).resolves.toBe(false);
+    });
+
+    it('should return false when /health throws', async () => {
+      mockGet.mockRejectedValueOnce(new Error('network error'));
+      await expect(plugin.healthCheck()).resolves.toBe(false);
+    });
+  });
+
+  describe('shutdown', () => {
+    it('should shutdown cleanly', async () => {
+      await plugin.initialize(testConfig);
+      await expect(plugin.shutdown()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/tests/plugins/outputs/index.test.ts
+++ b/tests/plugins/outputs/index.test.ts
@@ -4,6 +4,7 @@ import {
   BaseOutputPlugin,
   InfluxDB1Plugin,
   InfluxDB2Plugin,
+  VictoriaMetricsPlugin,
 } from '../../../src/plugins/outputs';
 
 describe('Output Plugins Index', () => {
@@ -17,11 +18,12 @@ describe('Output Plugins Index', () => {
       const registry = getOutputPluginRegistry();
       expect(registry.has('influxdb1')).toBe(true);
       expect(registry.has('influxdb2')).toBe(true);
+      expect(registry.has('victoriametrics')).toBe(true);
     });
 
     it('should have correct number of plugins', () => {
       const registry = getOutputPluginRegistry();
-      expect(registry.size).toBe(2);
+      expect(registry.size).toBe(3);
     });
 
     it('should return plugin classes that can be instantiated', () => {
@@ -43,6 +45,9 @@ describe('Output Plugins Index', () => {
 
       const influx2Plugin = new InfluxDB2Plugin();
       expect(registry.has(influx2Plugin.metadata.name.toLowerCase())).toBe(true);
+
+      const vmPlugin = new VictoriaMetricsPlugin();
+      expect(registry.has(vmPlugin.metadata.name.toLowerCase())).toBe(true);
     });
   });
 
@@ -57,6 +62,10 @@ describe('Output Plugins Index', () => {
 
     it('should export InfluxDB2Plugin', () => {
       expect(InfluxDB2Plugin).toBeDefined();
+    });
+
+    it('should export VictoriaMetricsPlugin', () => {
+      expect(VictoriaMetricsPlugin).toBeDefined();
     });
   });
 });


### PR DESCRIPTION
## Description

Adds a new `VictoriaMetricsPlugin` output that writes data to VictoriaMetrics using the InfluxDB line protocol over HTTP.

- New plugin `src/plugins/outputs/VictoriaMetricsPlugin.ts` extending `BaseOutputPlugin`
- Reuses `toLineProtocolBatch()` from the base class (no new dependency; uses existing `axios`)
- `POST /write` for ingestion, `GET /health` for health checks
- Registered in the output plugin registry (`src/plugins/outputs/index.ts`)
- 11 new unit tests + registry tests updated

The config schema (`VictoriaMetricsConfigSchema`) and example config were already in place; only the plugin implementation was missing.

## Type of change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [ ] Dependencies update

## Checklist
- [x] I have tested my changes locally
- [x] I have added/updated tests if needed
- [x] Code coverage is maintained or improved
- [x] Lint passes (`npm run lint`)
- [x] Tests pass (`npm test`) — 537 passed (+12)

## Related

Part of Phase 8 (Additional Output Plugins) in PLAN.md.