### PR TITLE
feat(utils): add environment variable validation at startup

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -369,12 +369,12 @@ interface ScheduleConfig {
   - Reduce load on source services
   - Effort: ~4h
 
-#### Environment Variable Validation
-- [ ] Create `src/utils/env.ts` for env var validation
-  - Check directory permissions (CONFIG_FOLDER, DATA_FOLDER, LOG_FOLDER)
-  - Validate required vars for enabled features
-  - Warn on deprecated vars
-  - Effort: ~2h
+#### Environment Variable Validation ✅
+- [x] Create `src/utils/env.ts` for env var validation
+  - Checks directory permissions (CONFIG_FOLDER, DATA_FOLDER, LOG_FOLDER) — creates if missing
+  - Validates HEALTH_PORT, HEALTH_ENABLED, DRY_RUN, LOG_LEVEL
+  - Warns on deprecated VRKN_* variables
+  - Called from `main()` at startup — errors abort, warnings are logged
 
 #### Structured Logging (JSON)
 - [ ] Update Logger for JSON output in production

--- a/README.md
+++ b/README.md
@@ -443,6 +443,13 @@ Legacy `VRKN_*` environment variables are also automatically migrated.
 
 ### Common Issues
 
+**Varken fails at startup with "Environment validation failed":**
+- Varken validates all environment variables and directory permissions on startup
+- Check `HEALTH_PORT` is a valid TCP port (1-65535)
+- Check `HEALTH_ENABLED`, `DRY_RUN` are set to `true` or `false` only
+- Check `LOG_LEVEL` is one of `error`, `warn`, `info`, `http`, `verbose`, `debug`, `silly`
+- Verify the process can read `CONFIG_FOLDER` and write to `DATA_FOLDER` / `LOG_FOLDER`
+
 **Varken can't connect to services:**
 - Verify URLs are accessible from the Varken container
 - Check API keys are correct

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { Orchestrator } from './core/Orchestrator';
 import { getInputPluginRegistry } from './plugins/inputs';
 import { getOutputPluginRegistry } from './plugins/outputs';
 import type { HealthServerConfig } from './core/HealthServer';
+import { validateEnvironment } from './utils/env';
 import { version as VERSION } from '../package.json';
 
 export { VERSION };
@@ -15,6 +16,7 @@ export interface MainDependencies {
   Orchestrator: typeof Orchestrator;
   getInputPluginRegistry: typeof getInputPluginRegistry;
   getOutputPluginRegistry: typeof getOutputPluginRegistry;
+  validateEnvironment: typeof validateEnvironment;
 }
 
 const defaultDependencies: MainDependencies = {
@@ -23,6 +25,7 @@ const defaultDependencies: MainDependencies = {
   Orchestrator,
   getInputPluginRegistry,
   getOutputPluginRegistry,
+  validateEnvironment,
 };
 
 export function isDryRun(argv: string[] = process.argv, env: NodeJS.ProcessEnv = process.env): boolean {
@@ -38,6 +41,18 @@ export async function main(deps: MainDependencies = defaultDependencies): Promis
   const dryRun = isDryRun();
 
   logger.info(`Varken v${VERSION} starting...`);
+
+  const { errors, warnings } = deps.validateEnvironment();
+  for (const warning of warnings) {
+    logger.warn(warning);
+  }
+  if (errors.length > 0) {
+    for (const error of errors) {
+      logger.error(error);
+    }
+    throw new Error(`Environment validation failed with ${errors.length} error(s)`);
+  }
+
   logger.info(`Config folder: ${configFolder}`);
   logger.info(`Data folder: ${dataFolder}`);
   if (dryRun) {

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,0 +1,115 @@
+import fs from 'fs';
+import path from 'path';
+
+export interface EnvValidationResult {
+  errors: string[];
+  warnings: string[];
+}
+
+export interface EnvValidationOptions {
+  env?: NodeJS.ProcessEnv;
+  fsModule?: Pick<typeof fs, 'existsSync' | 'mkdirSync' | 'accessSync' | 'constants'>;
+}
+
+const VALID_LOG_LEVELS = ['error', 'warn', 'info', 'http', 'verbose', 'debug', 'silly'];
+const VALID_BOOLEAN_STRINGS = ['true', 'false'];
+
+/**
+ * Validate environment variables and directory permissions before startup.
+ *
+ * Errors indicate configuration that will prevent Varken from running.
+ * Warnings indicate recoverable issues or deprecated usage.
+ */
+export function validateEnvironment(
+  options: EnvValidationOptions = {}
+): EnvValidationResult {
+  const env = options.env ?? process.env;
+  const fsMod = options.fsModule ?? fs;
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  validatePort(env.HEALTH_PORT, 'HEALTH_PORT', errors);
+  validateBoolean(env.HEALTH_ENABLED, 'HEALTH_ENABLED', errors);
+  validateBoolean(env.DRY_RUN, 'DRY_RUN', errors);
+  validateLogLevel(env.LOG_LEVEL, errors);
+
+  validateDirectory(env.CONFIG_FOLDER || './config', 'CONFIG_FOLDER', 'read', fsMod, errors);
+  validateDirectory(env.DATA_FOLDER || './data', 'DATA_FOLDER', 'write', fsMod, errors);
+  validateDirectory(env.LOG_FOLDER || './logs', 'LOG_FOLDER', 'write', fsMod, errors);
+
+  detectLegacyVars(env, warnings);
+
+  return { errors, warnings };
+}
+
+function validatePort(value: string | undefined, name: string, errors: string[]): void {
+  if (value === undefined || value === '') {
+    return;
+  }
+  const port = Number(value);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    errors.push(`${name}="${value}" is not a valid TCP port (expected integer 1-65535)`);
+  }
+}
+
+function validateBoolean(value: string | undefined, name: string, errors: string[]): void {
+  if (value === undefined || value === '') {
+    return;
+  }
+  if (!VALID_BOOLEAN_STRINGS.includes(value.toLowerCase())) {
+    errors.push(`${name}="${value}" is not a valid boolean (expected "true" or "false")`);
+  }
+}
+
+function validateLogLevel(value: string | undefined, errors: string[]): void {
+  if (value === undefined || value === '') {
+    return;
+  }
+  if (!VALID_LOG_LEVELS.includes(value.toLowerCase())) {
+    errors.push(
+      `LOG_LEVEL="${value}" is not a valid log level (expected one of: ${VALID_LOG_LEVELS.join(', ')})`
+    );
+  }
+}
+
+function validateDirectory(
+  dirPath: string,
+  name: string,
+  mode: 'read' | 'write',
+  fsMod: NonNullable<EnvValidationOptions['fsModule']>,
+  errors: string[]
+): void {
+  const resolved = path.resolve(dirPath);
+
+  if (!fsMod.existsSync(resolved)) {
+    try {
+      fsMod.mkdirSync(resolved, { recursive: true });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      errors.push(`${name}="${dirPath}" does not exist and could not be created: ${message}`);
+      return;
+    }
+  }
+
+  const accessMode = mode === 'write'
+    ? fsMod.constants.R_OK | fsMod.constants.W_OK
+    : fsMod.constants.R_OK;
+
+  try {
+    fsMod.accessSync(resolved, accessMode);
+  } catch {
+    errors.push(
+      `${name}="${dirPath}" is not ${mode === 'write' ? 'writable' : 'readable'} by the current user`
+    );
+  }
+}
+
+function detectLegacyVars(env: NodeJS.ProcessEnv, warnings: string[]): void {
+  const legacyKeys = Object.keys(env).filter((key) => key.startsWith('VRKN_'));
+  if (legacyKeys.length > 0) {
+    warnings.push(
+      `Found ${legacyKeys.length} legacy VRKN_* environment variable(s): ${legacyKeys.join(', ')}. ` +
+        'These will be migrated on first startup but should be removed afterwards — use VARKEN_* overrides instead.'
+    );
+  }
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -10,5 +10,9 @@ export {
   withTimeout,
 } from './http';
 
+// Environment validation
+export { validateEnvironment } from './env';
+export type { EnvValidationResult, EnvValidationOptions } from './env';
+
 // Re-export types
 export type { HttpClientConfig, RetryConfig } from '../types/http.types';

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -91,6 +91,7 @@ describe('index.ts (Entry Point)', () => {
       Orchestrator: MockOrchestrator as unknown as MainDependencies['Orchestrator'],
       getInputPluginRegistry: () => mockInputRegistry as unknown as ReturnType<MainDependencies['getInputPluginRegistry']>,
       getOutputPluginRegistry: () => mockOutputRegistry as unknown as ReturnType<MainDependencies['getOutputPluginRegistry']>,
+      validateEnvironment: vi.fn().mockReturnValue({ errors: [], warnings: [] }),
     };
   });
 
@@ -356,6 +357,31 @@ describe('index.ts (Entry Point)', () => {
         (call: unknown[]) => typeof call[0] === 'string' && call[0].includes('Health endpoint')
       );
       expect(healthCalls).toHaveLength(0);
+    });
+  });
+
+  describe('Environment validation', () => {
+    it('should log warnings returned by validateEnvironment', async () => {
+      mockDeps.validateEnvironment = vi.fn().mockReturnValue({
+        errors: [],
+        warnings: ['legacy VRKN_* variables detected'],
+      });
+
+      await main(mockDeps);
+
+      expect(mockLogger.warn).toHaveBeenCalledWith('legacy VRKN_* variables detected');
+    });
+
+    it('should throw when validateEnvironment returns errors', async () => {
+      mockDeps.validateEnvironment = vi.fn().mockReturnValue({
+        errors: ['HEALTH_PORT="nope" is not a valid TCP port'],
+        warnings: [],
+      });
+
+      await expect(main(mockDeps)).rejects.toThrow('Environment validation failed');
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        'HEALTH_PORT="nope" is not a valid TCP port'
+      );
     });
   });
 });

--- a/tests/utils/env.test.ts
+++ b/tests/utils/env.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi } from 'vitest';
+import fs from 'fs';
+import { validateEnvironment, type EnvValidationOptions } from '../../src/utils/env';
+
+type FsMock = NonNullable<EnvValidationOptions['fsModule']>;
+
+function makeFsMock(overrides?: {
+  existsSync?: ReturnType<typeof vi.fn>;
+  mkdirSync?: ReturnType<typeof vi.fn>;
+  accessSync?: ReturnType<typeof vi.fn>;
+}): FsMock {
+  return {
+    existsSync: (overrides?.existsSync ?? vi.fn().mockReturnValue(true)) as FsMock['existsSync'],
+    mkdirSync: (overrides?.mkdirSync ?? vi.fn()) as FsMock['mkdirSync'],
+    accessSync: (overrides?.accessSync ?? vi.fn()) as FsMock['accessSync'],
+    constants: fs.constants,
+  };
+}
+
+describe('validateEnvironment', () => {
+  describe('HEALTH_PORT', () => {
+    it('accepts a valid port', () => {
+      const result = validateEnvironment({ env: { HEALTH_PORT: '9090' }, fsModule: makeFsMock() });
+      expect(result.errors).toEqual([]);
+    });
+
+    it('rejects a non-numeric port', () => {
+      const result = validateEnvironment({ env: { HEALTH_PORT: 'nope' }, fsModule: makeFsMock() });
+      expect(result.errors).toEqual(
+        expect.arrayContaining([expect.stringContaining('HEALTH_PORT="nope"')])
+      );
+    });
+
+    it('rejects a port out of range', () => {
+      const result = validateEnvironment({ env: { HEALTH_PORT: '70000' }, fsModule: makeFsMock() });
+      expect(result.errors).toEqual(
+        expect.arrayContaining([expect.stringContaining('HEALTH_PORT="70000"')])
+      );
+    });
+
+    it('ignores an empty or missing value', () => {
+      expect(validateEnvironment({ env: {}, fsModule: makeFsMock() }).errors).toEqual([]);
+      expect(validateEnvironment({ env: { HEALTH_PORT: '' }, fsModule: makeFsMock() }).errors).toEqual([]);
+    });
+  });
+
+  describe('HEALTH_ENABLED', () => {
+    it('accepts "true" and "false" (case-insensitive)', () => {
+      expect(validateEnvironment({ env: { HEALTH_ENABLED: 'true' }, fsModule: makeFsMock() }).errors).toEqual([]);
+      expect(validateEnvironment({ env: { HEALTH_ENABLED: 'FALSE' }, fsModule: makeFsMock() }).errors).toEqual([]);
+    });
+
+    it('rejects any other value', () => {
+      const result = validateEnvironment({ env: { HEALTH_ENABLED: 'yes' }, fsModule: makeFsMock() });
+      expect(result.errors).toEqual(
+        expect.arrayContaining([expect.stringContaining('HEALTH_ENABLED="yes"')])
+      );
+    });
+  });
+
+  describe('DRY_RUN', () => {
+    it('rejects invalid boolean values', () => {
+      const result = validateEnvironment({ env: { DRY_RUN: '1' }, fsModule: makeFsMock() });
+      expect(result.errors).toEqual(
+        expect.arrayContaining([expect.stringContaining('DRY_RUN="1"')])
+      );
+    });
+  });
+
+  describe('LOG_LEVEL', () => {
+    it('accepts standard winston levels', () => {
+      for (const level of ['error', 'warn', 'info', 'debug']) {
+        const result = validateEnvironment({ env: { LOG_LEVEL: level }, fsModule: makeFsMock() });
+        expect(result.errors).toEqual([]);
+      }
+    });
+
+    it('rejects an unknown level', () => {
+      const result = validateEnvironment({ env: { LOG_LEVEL: 'chatty' }, fsModule: makeFsMock() });
+      expect(result.errors).toEqual(
+        expect.arrayContaining([expect.stringContaining('LOG_LEVEL="chatty"')])
+      );
+    });
+  });
+
+  describe('directories', () => {
+    it('creates missing directories and reports no error', () => {
+      const mkdirSync = vi.fn();
+      const result = validateEnvironment({
+        env: { CONFIG_FOLDER: '/tmp/varken-test-config' },
+        fsModule: makeFsMock({ existsSync: vi.fn().mockReturnValue(false), mkdirSync }),
+      });
+      expect(mkdirSync).toHaveBeenCalled();
+      expect(result.errors).toEqual([]);
+    });
+
+    it('reports an error if directory cannot be created', () => {
+      const result = validateEnvironment({
+        env: { DATA_FOLDER: '/root/forbidden' },
+        fsModule: makeFsMock({
+          existsSync: vi.fn().mockReturnValue(false),
+          mkdirSync: vi.fn().mockImplementation(() => {
+            throw new Error('EACCES: permission denied');
+          }),
+        }),
+      });
+      expect(result.errors).toEqual(
+        expect.arrayContaining([expect.stringContaining('DATA_FOLDER="/root/forbidden"')])
+      );
+    });
+
+    it('reports an error if directory is not writable', () => {
+      const result = validateEnvironment({
+        env: { LOG_FOLDER: '/readonly' },
+        fsModule: makeFsMock({
+          accessSync: vi.fn().mockImplementation(() => {
+            throw new Error('EACCES');
+          }),
+        }),
+      });
+      expect(result.errors).toEqual(
+        expect.arrayContaining([expect.stringContaining('LOG_FOLDER="/readonly"')])
+      );
+    });
+  });
+
+  describe('legacy vars', () => {
+    it('warns when VRKN_* variables are present', () => {
+      const result = validateEnvironment({
+        env: { VRKN_SONARR_1_URL: 'http://localhost:8989' },
+        fsModule: makeFsMock(),
+      });
+      expect(result.warnings).toEqual(
+        expect.arrayContaining([expect.stringContaining('VRKN_SONARR_1_URL')])
+      );
+    });
+
+    it('does not warn when no VRKN_* variables are present', () => {
+      const result = validateEnvironment({ env: {}, fsModule: makeFsMock() });
+      expect(result.warnings).toEqual([]);
+    });
+  });
+
+  describe('result shape', () => {
+    it('always returns errors and warnings arrays', () => {
+      const result = validateEnvironment({ env: {}, fsModule: makeFsMock() });
+      expect(Array.isArray(result.errors)).toBe(true);
+      expect(Array.isArray(result.warnings)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Adds a dedicated environment validation step that runs at startup, before config loading. Catches misconfiguration early with clear error messages instead of failing cryptically later.

**New module `src/utils/env.ts`:**
- Validates env var values: `HEALTH_PORT` (TCP port), `HEALTH_ENABLED` / `DRY_RUN` (booleans), `LOG_LEVEL` (winston levels)
- Checks directory permissions: `CONFIG_FOLDER` (readable), `DATA_FOLDER` / `LOG_FOLDER` (writable)
- Auto-creates missing directories when possible
- Warns on legacy `VRKN_*` variables (suggests migration to `VARKEN_*`)
- Returns `{ errors, warnings }` — errors abort startup, warnings are just logged

**Integration in `main()`:**
- Called right after logger creation, before config loading
- Errors throw `Environment validation failed with N error(s)` → process exits with 1
- Warnings are logged via `logger.warn` and startup continues

**Testing:**
- 100% line coverage on `env.ts` (15 new tests)
- Injected `fsModule` allows pure unit tests without touching the real filesystem
- `MainDependencies` extended with `validateEnvironment` for DI-friendly testing of the main flow

## Type of change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [ ] Dependencies update

## Checklist
- [x] I have tested my changes locally
- [x] I have added/updated tests if needed
- [x] Code coverage is maintained or improved
- [x] Lint passes (`npm run lint`)
- [x] Tests pass (`npm test`) — 567 passed (+17)

## Related

Part of Phase 11 (Developer Experience) in PLAN.md.