### PR TITLE
feat(core): add Prometheus /metrics endpoint with prom-client

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -68,7 +68,7 @@ varken/
 │   └── utils/
 │       ├── http.ts                  # HTTP utilities, error classification
 │       └── index.ts
-├── tests/                           # 571 tests, 91% coverage
+├── tests/                           # 591 tests, 91% coverage
 │   ├── config/
 │   ├── core/
 │   ├── plugins/
@@ -228,7 +228,7 @@ interface ScheduleConfig {
 - [x] Main entry point (`index.ts`)
 - [x] Dockerfile (multi-stage, ~190MB)
 - [x] docker-compose.yml (Varken + InfluxDB 2.x + Grafana)
-- [x] Unit tests (571 tests passing)
+- [x] Unit tests (591 tests passing)
 - [x] CI/CD workflows (GitHub Actions)
 - [x] Codecov integration
 - [x] Documentation (README.md, CLAUDE.md)
@@ -247,12 +247,13 @@ interface ScheduleConfig {
   - Add `HEALTH_PORT` env var (default: 9090)
   - Add `HEALTH_ENABLED` env var (default: true)
 
-#### Prometheus Metrics
-- [ ] Create `src/core/Metrics.ts` - Metrics collection
-  - `GET /metrics` → Prometheus format
-  - Metrics: collections count, errors, durations, data points collected/written
-  - Add `prom-client` dependency
-  - Effort: ~8h
+#### Prometheus Metrics ✅
+- [x] Create `src/core/Metrics.ts` - Metrics collection
+  - `GET /metrics` on the health server port (Prometheus text format)
+  - Metrics: collections count + duration, data points collected/written, scheduler errors, circuit breaker state, active plugins count
+  - Default Node.js process metrics included
+  - `METRICS_ENABLED` env var (default `true`)
+  - `prom-client` dependency added
 
 #### Circuit Breaker & Error Recovery ✅
 - [x] Track consecutive failures per schedule (`PluginManager.ts`)
@@ -445,14 +446,15 @@ interface ScheduleConfig {
 
 ## Test Coverage Summary
 
-> **Last updated**: 2026-04-24 | **Global coverage**: 91.35% | **Tests**: 571 passing
+> **Last updated**: 2026-04-24 | **Global coverage**: 91.44% | **Tests**: 591 passing
 
 | File | Coverage | Target | Status | Notes |
 |------|----------|--------|--------|-------|
 | `src/index.ts` | 95.34% | 80% | ✅ | |
-| `src/core/HealthServer.ts` | 87.15% | 90% | ⚠️ | |
-| `src/core/Orchestrator.ts` | 80% | 85% | ⚠️ | Signal handlers can't be tested (interfere with vitest) |
-| `src/core/PluginManager.ts` | 93.89% | 90% | ✅ | |
+| `src/core/HealthServer.ts` | 85.93% | 90% | ⚠️ | |
+| `src/core/Metrics.ts` | 100% | 90% | ✅ | Added in Phase 7 (Prometheus) |
+| `src/core/Orchestrator.ts` | 80.86% | 85% | ⚠️ | Signal handlers can't be tested (interfere with vitest) |
+| `src/core/PluginManager.ts` | 94.15% | 90% | ✅ | |
 | `src/core/Logger.ts` | 77.27% | 90% | ⚠️ | Regression vs 2026-02 — directory-creation path and filter callback untested |
 | `src/config/ConfigLoader.ts` | 81.72% | 90% | ⚠️ | |
 | `src/config/ConfigMigrator.ts` | 92.12% | 85% | ✅ | |
@@ -533,13 +535,13 @@ DataPoint (internal format)
 ### Medium Priority
 | Item | Effort | Impact |
 |------|--------|--------|
-| Prometheus metrics | ~8h | Observability |
+| ~~Prometheus metrics~~ | ~~✅~~ | ~~Observability~~ |
 | Config hot-reload | ~8h | Operations |
 | QuestDB, TimescaleDB outputs | ~14h | More DB options |
 | Structured logging | ~4h | Debugging |
 | ~~Dry-run mode~~ | ~~✅~~ | ~~`--dry-run` / `DRY_RUN=true`~~ |
 | Better error messages | ~4h | UX |
-| ~~Improve test coverage~~ | ~~✅~~ | ~~Quality - Global 91.35%~~ |
+| ~~Improve test coverage~~ | ~~✅~~ | ~~Quality - Global 91.44%~~ |
 
 ### Low Priority
 | Item | Effort | Impact |

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Built with TypeScript, Node.js, and a plugin-based architecture with scheduled d
 
 - **Circuit breaker** — automatic error recovery with exponential backoff and self-healing
 - **Health checks** — built-in HTTP endpoints for monitoring and orchestration
+- **Prometheus metrics** — `/metrics` endpoint for collection counts, durations, errors, and circuit breaker state
 - **Graceful output skipping** — failed output plugins are skipped at startup; Varken continues with the ones that initialized successfully
 - **Easy configuration** — simple YAML config with environment variable overrides
 
@@ -238,6 +239,7 @@ global:
 | `TZ`             | `UTC`     | Timezone (e.g., `Europe/Paris`, `America/New_York`) |
 | `HEALTH_PORT`    | `9090`    | Port for the health check HTTP server               |
 | `HEALTH_ENABLED` | `true`    | Enable/disable the health check server              |
+| `METRICS_ENABLED`| `true`    | Enable/disable the Prometheus `/metrics` endpoint   |
 | `DRY_RUN`        | `false`   | Run once without writing (equivalent to `--dry-run`) |
 
 #### Configuration Overrides
@@ -388,6 +390,7 @@ Varken exposes HTTP endpoints for monitoring on port `9090` (configurable via `H
 | `GET /health`         | Overall status: `healthy`, `degraded`, `unhealthy` |
 | `GET /health/plugins` | Per-plugin health status (inputs and outputs)      |
 | `GET /status`         | Detailed status with scheduler information         |
+| `GET /metrics`        | Prometheus scrape endpoint (see below)             |
 
 The Docker image includes a built-in `HEALTHCHECK` instruction using these endpoints.
 
@@ -406,6 +409,33 @@ The Docker image includes a built-in `HEALTHCHECK` instruction using these endpo
 | `healthy`   | All outputs healthy + all inputs healthy + all schedulers in `closed` state with < 3 errors |
 | `degraded`  | At least one output healthy + at least one scheduler not in `open` state                    |
 | `unhealthy` | No outputs configured, all outputs unreachable, or all schedulers in `open` state           |
+
+## Prometheus Metrics
+
+Varken exposes a Prometheus scrape endpoint at `GET /metrics` on the same port as the health server (default `9090`). Disable with `METRICS_ENABLED=false`.
+
+### Exposed Metrics
+
+| Metric                               | Type      | Labels              | Description                                            |
+|--------------------------------------|-----------|---------------------|--------------------------------------------------------|
+| `varken_collections_total`           | counter   | scheduler, status   | Scheduled collector runs (status: success / failure)   |
+| `varken_collection_duration_seconds` | histogram | scheduler           | Collector run duration                                 |
+| `varken_data_points_collected_total` | counter   | scheduler           | Data points produced by collectors                     |
+| `varken_data_points_written_total`   | counter   | output, status      | Data points written to outputs (status / failure)      |
+| `varken_scheduler_errors_total`      | counter   | scheduler           | Total scheduler errors                                 |
+| `varken_circuit_breaker_state`       | gauge     | scheduler           | Circuit breaker state (0=closed, 1=half-open, 2=open)  |
+| `varken_active_plugins`              | gauge     | kind                | Active plugin count by kind (input / output)           |
+
+Default Node.js process metrics (`process_cpu_*`, `nodejs_heap_*`, event loop lag, GC stats) are also exposed.
+
+### Prometheus Scrape Config
+
+```yaml
+scrape_configs:
+  - job_name: varken
+    static_configs:
+      - targets: ['varken:9090']
+```
 
 ## Grafana Setup
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@influxdata/influxdb-client-apis": "^1.35.0",
         "axios": "^1.15.0",
         "influx": "^5.12.0",
+        "prom-client": "^15.1.3",
         "winston": "^3.17.0",
         "yaml": "^2.8.3",
         "zod": "^4.3.6"
@@ -795,6 +796,15 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -1644,6 +1654,12 @@
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "5.0.5",
@@ -3402,6 +3418,19 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
@@ -3714,6 +3743,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/text-hex": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js",
     "build": "tsc",
-    "build": "tsc",
     "clean": "rm -rf dist .reports node_modules logs data",
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
@@ -47,6 +46,7 @@
     "@influxdata/influxdb-client-apis": "^1.35.0",
     "axios": "^1.15.0",
     "influx": "^5.12.0",
+    "prom-client": "^15.1.3",
     "winston": "^3.17.0",
     "yaml": "^2.8.3",
     "zod": "^4.3.6"

--- a/src/core/HealthServer.ts
+++ b/src/core/HealthServer.ts
@@ -1,5 +1,6 @@
 import http from 'node:http';
 import { createLogger } from './Logger';
+import type { Metrics } from './Metrics';
 import type { PluginManager } from './PluginManager';
 import type {
   HealthStatus,
@@ -32,6 +33,7 @@ export interface HealthServerConfig {
 export class HealthServer {
   private server: http.Server | null = null;
   private pluginManager: PluginManager | null = null;
+  private metrics: Metrics | null = null;
   private config: HealthServerConfig;
   private startTime: Date;
 
@@ -45,6 +47,14 @@ export class HealthServer {
    */
   setPluginManager(pluginManager: PluginManager): void {
     this.pluginManager = pluginManager;
+  }
+
+  /**
+   * Attach a Metrics registry so `/metrics` exposes Prometheus-format data.
+   * If unset, `/metrics` returns 404.
+   */
+  setMetrics(metrics: Metrics | null): void {
+    this.metrics = metrics;
   }
 
   /**
@@ -103,15 +113,22 @@ export class HealthServer {
     const url = req.url || '/';
     const method = req.method || 'GET';
 
-    // Set CORS and content type headers
-    res.setHeader('Content-Type', 'application/json');
     res.setHeader('Access-Control-Allow-Origin', '*');
 
     // Only allow GET requests
     if (method !== 'GET') {
+      res.setHeader('Content-Type', 'application/json');
       this.sendError(res, 405, 'Method Not Allowed');
       return;
     }
+
+    // /metrics returns Prometheus text format; all other endpoints return JSON
+    if (url === '/metrics') {
+      await this.handleMetrics(res);
+      return;
+    }
+
+    res.setHeader('Content-Type', 'application/json');
 
     // Route requests
     switch (url) {
@@ -126,6 +143,29 @@ export class HealthServer {
         break;
       default:
         this.sendError(res, 404, 'Not Found');
+    }
+  }
+
+  /**
+   * GET /metrics - Prometheus scrape endpoint
+   */
+  private async handleMetrics(res: http.ServerResponse): Promise<void> {
+    if (!this.metrics) {
+      res.setHeader('Content-Type', 'application/json');
+      this.sendError(res, 404, 'Metrics not enabled');
+      return;
+    }
+
+    try {
+      const body = await this.metrics.getMetrics();
+      res.setHeader('Content-Type', this.metrics.getContentType());
+      res.statusCode = 200;
+      res.end(body);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      logger.error(`Metrics scrape failed: ${message}`);
+      res.setHeader('Content-Type', 'application/json');
+      this.sendError(res, 500, 'Internal Server Error');
     }
   }
 

--- a/src/core/Metrics.ts
+++ b/src/core/Metrics.ts
@@ -1,0 +1,118 @@
+import { Registry, Counter, Histogram, Gauge, collectDefaultMetrics } from 'prom-client';
+
+/**
+ * Metrics registry and definitions for Prometheus scraping.
+ *
+ * Exposes per-scheduler collection metrics (counts, durations, errors),
+ * per-output write metrics, and circuit breaker state.
+ * Default Node.js process metrics (CPU, memory, event loop) are also registered.
+ */
+export class Metrics {
+  readonly registry: Registry;
+
+  readonly collectionsTotal: Counter<'scheduler' | 'status'>;
+  readonly collectionDuration: Histogram<'scheduler'>;
+  readonly dataPointsCollected: Counter<'scheduler'>;
+  readonly dataPointsWritten: Counter<'output' | 'status'>;
+  readonly schedulerErrors: Counter<'scheduler'>;
+  readonly circuitBreakerState: Gauge<'scheduler'>;
+  readonly activePlugins: Gauge<'kind'>;
+
+  constructor() {
+    this.registry = new Registry();
+    this.registry.setDefaultLabels({ app: 'varken' });
+    collectDefaultMetrics({ register: this.registry });
+
+    this.collectionsTotal = new Counter({
+      name: 'varken_collections_total',
+      help: 'Total number of scheduled collector runs, labelled by status',
+      labelNames: ['scheduler', 'status'] as const,
+      registers: [this.registry],
+    });
+
+    this.collectionDuration = new Histogram({
+      name: 'varken_collection_duration_seconds',
+      help: 'Duration of scheduled collector runs in seconds',
+      labelNames: ['scheduler'] as const,
+      buckets: [0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60],
+      registers: [this.registry],
+    });
+
+    this.dataPointsCollected = new Counter({
+      name: 'varken_data_points_collected_total',
+      help: 'Total number of data points produced by collectors',
+      labelNames: ['scheduler'] as const,
+      registers: [this.registry],
+    });
+
+    this.dataPointsWritten = new Counter({
+      name: 'varken_data_points_written_total',
+      help: 'Total number of data points written to outputs, labelled by status',
+      labelNames: ['output', 'status'] as const,
+      registers: [this.registry],
+    });
+
+    this.schedulerErrors = new Counter({
+      name: 'varken_scheduler_errors_total',
+      help: 'Total number of scheduler errors',
+      labelNames: ['scheduler'] as const,
+      registers: [this.registry],
+    });
+
+    this.circuitBreakerState = new Gauge({
+      name: 'varken_circuit_breaker_state',
+      help: 'Circuit breaker state per scheduler (0=closed, 1=half-open, 2=open)',
+      labelNames: ['scheduler'] as const,
+      registers: [this.registry],
+    });
+
+    this.activePlugins = new Gauge({
+      name: 'varken_active_plugins',
+      help: 'Number of active plugins by kind (input/output)',
+      labelNames: ['kind'] as const,
+      registers: [this.registry],
+    });
+  }
+
+  recordCollection(scheduler: string, durationSeconds: number, success: boolean): void {
+    this.collectionsTotal.inc({ scheduler, status: success ? 'success' : 'failure' });
+    this.collectionDuration.observe({ scheduler }, durationSeconds);
+    if (!success) {
+      this.schedulerErrors.inc({ scheduler });
+    }
+  }
+
+  recordDataPointsCollected(scheduler: string, count: number): void {
+    if (count > 0) {
+      this.dataPointsCollected.inc({ scheduler }, count);
+    }
+  }
+
+  recordWrite(output: string, count: number, success: boolean): void {
+    if (count > 0) {
+      this.dataPointsWritten.inc({ output, status: success ? 'success' : 'failure' }, count);
+    }
+  }
+
+  setCircuitBreakerState(scheduler: string, state: 'closed' | 'half-open' | 'open'): void {
+    const numeric = state === 'closed' ? 0 : state === 'half-open' ? 1 : 2;
+    this.circuitBreakerState.set({ scheduler }, numeric);
+  }
+
+  setActivePlugins(inputs: number, outputs: number): void {
+    this.activePlugins.set({ kind: 'input' }, inputs);
+    this.activePlugins.set({ kind: 'output' }, outputs);
+  }
+
+  async getMetrics(): Promise<string> {
+    return this.registry.metrics();
+  }
+
+  getContentType(): string {
+    return this.registry.contentType;
+  }
+
+  reset(): void {
+    this.registry.resetMetrics();
+  }
+}

--- a/src/core/Orchestrator.ts
+++ b/src/core/Orchestrator.ts
@@ -2,6 +2,7 @@ import { createLogger } from './Logger';
 import type { InputPluginFactory, OutputPluginFactory } from './PluginManager';
 import { PluginManager } from './PluginManager';
 import { HealthServer, type HealthServerConfig } from './HealthServer';
+import { Metrics } from './Metrics';
 import type { VarkenConfig } from '../config/schemas/config.schema';
 
 const logger = createLogger('Orchestrator');
@@ -23,15 +24,20 @@ export class Orchestrator {
   private healthServer: HealthServer | null = null;
   private config: VarkenConfig;
   private healthConfig?: HealthServerConfig;
+  private metrics: Metrics | null = null;
   private isRunning = false;
   private shutdownPromise: Promise<void> | null = null;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private signalHandlers: Array<{ event: string; handler: (...args: any[]) => void }> = [];
 
-  constructor(config: VarkenConfig, healthConfig?: HealthServerConfig) {
+  constructor(config: VarkenConfig, healthConfig?: HealthServerConfig, metricsEnabled = true) {
     this.config = config;
     this.healthConfig = healthConfig;
     this.pluginManager = new PluginManager();
+    if (metricsEnabled) {
+      this.metrics = new Metrics();
+      this.pluginManager.setMetrics(this.metrics);
+    }
   }
 
   /**
@@ -84,6 +90,7 @@ export class Orchestrator {
       if (this.healthConfig) {
         this.healthServer = new HealthServer(this.healthConfig);
         this.healthServer.setPluginManager(this.pluginManager);
+        this.healthServer.setMetrics(this.metrics);
         await this.healthServer.start();
       }
 

--- a/src/core/PluginManager.ts
+++ b/src/core/PluginManager.ts
@@ -1,4 +1,5 @@
 import { createLogger } from './Logger';
+import type { Metrics } from './Metrics';
 import { withTimeout } from '../utils/http';
 import type {
   InputPlugin,
@@ -78,6 +79,7 @@ export class PluginManager {
   private circuitBreakerConfig: CircuitBreakerConfig = DEFAULT_CIRCUIT_BREAKER_CONFIG;
   private config?: VarkenConfig;
   private dryRun = false;
+  private metrics: Metrics | null = null;
 
   constructor() {
     // No longer needs GeoIP handler - handled by TautulliPlugin via Tautulli API
@@ -89,6 +91,14 @@ export class PluginManager {
    */
   setDryRun(enabled: boolean): void {
     this.dryRun = enabled;
+  }
+
+  /**
+   * Attach a Metrics registry so plugin activity is recorded for Prometheus scraping.
+   * If not set, no metrics are collected (legacy behavior).
+   */
+  setMetrics(metrics: Metrics | null): void {
+    this.metrics = metrics;
   }
 
   /**
@@ -163,6 +173,9 @@ export class PluginManager {
 
     // Initialize input plugins
     await this.initializeInputPlugins(config.inputs, config.global);
+
+    const stats = this.getStats();
+    this.metrics?.setActivePlugins(stats.activeInputPlugins, stats.activeOutputPlugins);
 
     logger.info('All plugins initialized successfully');
   }
@@ -314,6 +327,7 @@ export class PluginManager {
     };
 
     this.schedulers.set(schedule.name, activeScheduler);
+    this.metrics?.setCircuitBreakerState(schedule.name, 'closed');
 
     // Run immediately on start
     this.executeSchedule(schedule).catch((error) => {
@@ -405,10 +419,10 @@ export class PluginManager {
     }
 
     scheduler.isRunning = true;
+    const startTime = Date.now();
 
     try {
       logger.debug(`Executing schedule: ${schedule.name}`);
-      const startTime = Date.now();
 
       // Collect data from the plugin with configurable timeout
       const collectorTimeout = this.config?.global?.collectorTimeoutMs ?? 60000;
@@ -419,6 +433,7 @@ export class PluginManager {
       );
 
       const validPoints = this.validateDataPoints(points, schedule.name);
+      this.metrics?.recordDataPointsCollected(schedule.name, validPoints.length);
 
       if (validPoints.length > 0) {
         // Write to all output plugins
@@ -432,12 +447,14 @@ export class PluginManager {
       }
 
       // Handle success
+      this.metrics?.recordCollection(schedule.name, (Date.now() - startTime) / 1000, true);
       this.handleScheduleSuccess(scheduler);
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error';
       logger.error(`Schedule ${schedule.name} failed: ${message}`);
 
       // Handle failure
+      this.metrics?.recordCollection(schedule.name, (Date.now() - startTime) / 1000, false);
       this.handleScheduleFailure(scheduler, message);
     } finally {
       scheduler.isRunning = false;
@@ -521,6 +538,7 @@ export class PluginManager {
       Date.now() + this.circuitBreakerConfig.cooldownSeconds * 1000
     );
     scheduler.recoverySuccesses = 0;
+    this.metrics?.setCircuitBreakerState(scheduler.schedule.name, 'open');
 
     logger.warn(
       `Schedule ${scheduler.schedule.name} circuit opened after ${scheduler.consecutiveErrors} errors, ` +
@@ -536,6 +554,7 @@ export class PluginManager {
     scheduler.recoverySuccesses = 0;
     // Reset to base interval for recovery testing
     scheduler.currentIntervalMs = scheduler.baseIntervalMs;
+    this.metrics?.setCircuitBreakerState(scheduler.schedule.name, 'half-open');
 
     logger.info(
       `Schedule ${scheduler.schedule.name} circuit transitioning to half-open for recovery testing`
@@ -553,6 +572,7 @@ export class PluginManager {
     scheduler.disabledAt = undefined;
     scheduler.nextAttemptAt = undefined;
     scheduler.recoverySuccesses = 0;
+    this.metrics?.setCircuitBreakerState(scheduler.schedule.name, 'closed');
 
     logger.info(
       `Schedule ${scheduler.schedule.name} circuit closed, resuming normal operation`
@@ -596,9 +616,11 @@ export class PluginManager {
       async ([type, plugin]) => {
         try {
           await plugin.write(points);
+          this.metrics?.recordWrite(type, points.length, true);
           logger.debug(`Wrote ${points.length} points to ${type}`);
         } catch (error) {
           failureCount++;
+          this.metrics?.recordWrite(type, points.length, false);
           const message = error instanceof Error ? error.message : 'Unknown error';
           logger.error(`Failed to write to output ${type}: ${message}`);
           // Don't throw - continue with other outputs

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ export async function main(deps: MainDependencies = defaultDependencies): Promis
   const dataFolder = process.env.DATA_FOLDER || './data';
   const healthPort = parseInt(process.env.HEALTH_PORT || String(DEFAULT_HEALTH_PORT), 10);
   const healthEnabled = process.env.HEALTH_ENABLED !== 'false';
+  const metricsEnabled = process.env.METRICS_ENABLED !== 'false';
   const dryRun = isDryRun();
 
   logger.info(`Varken v${VERSION} starting...`);
@@ -59,6 +60,9 @@ export async function main(deps: MainDependencies = defaultDependencies): Promis
     logger.info('Mode: dry-run (no data will be written)');
   } else if (healthEnabled) {
     logger.info(`Health endpoint: http://0.0.0.0:${healthPort}/health`);
+    if (metricsEnabled) {
+      logger.info(`Metrics endpoint: http://0.0.0.0:${healthPort}/metrics`);
+    }
   }
 
   // Load and validate configuration
@@ -86,7 +90,7 @@ export async function main(deps: MainDependencies = defaultDependencies): Promis
 
   // Create and configure orchestrator
   // Note: GeoIP is now handled directly by TautulliPlugin via Tautulli API
-  const orchestrator = new deps.Orchestrator(config, healthConfig);
+  const orchestrator = new deps.Orchestrator(config, healthConfig, metricsEnabled);
 
   // Register plugins automatically from registries
   const inputPlugins = deps.getInputPluginRegistry();

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -30,6 +30,7 @@ export function validateEnvironment(
 
   validatePort(env.HEALTH_PORT, 'HEALTH_PORT', errors);
   validateBoolean(env.HEALTH_ENABLED, 'HEALTH_ENABLED', errors);
+  validateBoolean(env.METRICS_ENABLED, 'METRICS_ENABLED', errors);
   validateBoolean(env.DRY_RUN, 'DRY_RUN', errors);
   validateLogLevel(env.LOG_LEVEL, errors);
 

--- a/tests/core/HealthServer.test.ts
+++ b/tests/core/HealthServer.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import http from 'node:http';
 import { HealthServer, HealthServerConfig } from '../../src/core/HealthServer';
+import { Metrics } from '../../src/core/Metrics';
 import { PluginManager } from '../../src/core/PluginManager';
 import type { SchedulerStatus, PluginStatus } from '../../src/types/health.types';
 
@@ -474,6 +475,51 @@ describe('HealthServer', () => {
 
       expect(response.headers['content-type']).toBe('application/json');
       expect(response.headers['access-control-allow-origin']).toBe('*');
+    });
+  });
+
+  describe('GET /metrics', () => {
+    it('should return Prometheus-format metrics when metrics are attached', async () => {
+      const mockPm = createMockPluginManager();
+      const metrics = new Metrics();
+      metrics.recordCollection('sonarr_queue', 0.1, true);
+
+      healthServer.setPluginManager(mockPm);
+      healthServer.setMetrics(metrics);
+      await healthServer.start();
+
+      const response = await httpGet(testPort, '/metrics');
+
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toContain('varken_collections_total');
+      expect(response.body).toContain('app="varken"');
+    });
+
+    it('should return 404 when metrics are not attached', async () => {
+      const mockPm = createMockPluginManager();
+      healthServer.setPluginManager(mockPm);
+      await healthServer.start();
+
+      const response = await httpGet(testPort, '/metrics');
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it('should set the Prometheus text content type', async () => {
+      const mockPm = createMockPluginManager();
+      healthServer.setPluginManager(mockPm);
+      healthServer.setMetrics(new Metrics());
+      await healthServer.start();
+
+      const response = await new Promise<{ headers: http.IncomingHttpHeaders }>((resolve, reject) => {
+        const req = http.get(`http://localhost:${testPort}/metrics`, (res) => {
+          res.on('data', () => {});
+          res.on('end', () => resolve({ headers: res.headers }));
+        });
+        req.on('error', reject);
+      });
+
+      expect(response.headers['content-type']).toContain('text/plain');
     });
   });
 });

--- a/tests/core/Metrics.test.ts
+++ b/tests/core/Metrics.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Metrics } from '../../src/core/Metrics';
+
+describe('Metrics', () => {
+  let metrics: Metrics;
+
+  beforeEach(() => {
+    metrics = new Metrics();
+  });
+
+  describe('registry', () => {
+    it('should expose Prometheus text format on getMetrics()', async () => {
+      const output = await metrics.getMetrics();
+      expect(typeof output).toBe('string');
+      expect(output).toContain('# HELP');
+      expect(output).toContain('# TYPE');
+    });
+
+    it('should use the Prometheus content type', () => {
+      expect(metrics.getContentType()).toContain('text/plain');
+      expect(metrics.getContentType()).toContain('version=0.0.4');
+    });
+
+    it('should register default Node.js process metrics', async () => {
+      const output = await metrics.getMetrics();
+      expect(output).toContain('process_cpu_user_seconds_total');
+      expect(output).toContain('nodejs_heap_size_total_bytes');
+    });
+
+    it('should label every metric with app=varken', async () => {
+      metrics.recordCollection('demo', 0.1, true);
+      const output = await metrics.getMetrics();
+      expect(output).toMatch(/app="varken"/);
+    });
+  });
+
+  describe('recordCollection', () => {
+    it('should increment success counter and observe duration', async () => {
+      metrics.recordCollection('sonarr_queue', 0.42, true);
+      const output = await metrics.getMetrics();
+      expect(output).toMatch(/varken_collections_total\{.*status="success".*\} 1/);
+      expect(output).toMatch(/varken_collection_duration_seconds_sum\{[^}]*scheduler="sonarr_queue"[^}]*\}/);
+    });
+
+    it('should increment failure counter and scheduler_errors on failure', async () => {
+      metrics.recordCollection('sonarr_queue', 1.2, false);
+      const output = await metrics.getMetrics();
+      expect(output).toMatch(/varken_collections_total\{.*status="failure".*\} 1/);
+      expect(output).toMatch(/varken_scheduler_errors_total\{.*scheduler="sonarr_queue".*\} 1/);
+    });
+  });
+
+  describe('recordDataPointsCollected', () => {
+    it('should add to the counter when count > 0', async () => {
+      metrics.recordDataPointsCollected('sonarr_queue', 5);
+      const output = await metrics.getMetrics();
+      expect(output).toMatch(/varken_data_points_collected_total\{.*scheduler="sonarr_queue".*\} 5/);
+    });
+
+    it('should do nothing when count is zero', async () => {
+      metrics.recordDataPointsCollected('sonarr_queue', 0);
+      const output = await metrics.getMetrics();
+      expect(output).not.toMatch(/varken_data_points_collected_total\{[^}]*scheduler="sonarr_queue"/);
+    });
+  });
+
+  describe('recordWrite', () => {
+    it('should increment success counter', async () => {
+      metrics.recordWrite('influxdb2', 3, true);
+      const output = await metrics.getMetrics();
+      expect(output).toMatch(/varken_data_points_written_total\{.*output="influxdb2".*status="success".*\} 3/);
+    });
+
+    it('should increment failure counter', async () => {
+      metrics.recordWrite('influxdb2', 3, false);
+      const output = await metrics.getMetrics();
+      expect(output).toMatch(/varken_data_points_written_total\{.*status="failure".*\} 3/);
+    });
+
+    it('should skip when count is zero', async () => {
+      metrics.recordWrite('influxdb2', 0, true);
+      const output = await metrics.getMetrics();
+      expect(output).not.toMatch(/varken_data_points_written_total\{[^}]*output="influxdb2"/);
+    });
+  });
+
+  describe('setCircuitBreakerState', () => {
+    it('should map states to numeric values (closed=0, half-open=1, open=2)', async () => {
+      metrics.setCircuitBreakerState('a', 'closed');
+      metrics.setCircuitBreakerState('b', 'half-open');
+      metrics.setCircuitBreakerState('c', 'open');
+      const output = await metrics.getMetrics();
+      expect(output).toMatch(/varken_circuit_breaker_state\{[^}]*scheduler="a"[^}]*\} 0/);
+      expect(output).toMatch(/varken_circuit_breaker_state\{[^}]*scheduler="b"[^}]*\} 1/);
+      expect(output).toMatch(/varken_circuit_breaker_state\{[^}]*scheduler="c"[^}]*\} 2/);
+    });
+  });
+
+  describe('setActivePlugins', () => {
+    it('should set input and output plugin gauges', async () => {
+      metrics.setActivePlugins(3, 2);
+      const output = await metrics.getMetrics();
+      expect(output).toMatch(/varken_active_plugins\{[^}]*kind="input"[^}]*\} 3/);
+      expect(output).toMatch(/varken_active_plugins\{[^}]*kind="output"[^}]*\} 2/);
+    });
+  });
+
+  describe('reset', () => {
+    it('should zero out recorded counters', async () => {
+      metrics.recordCollection('sonarr_queue', 0.1, true);
+      metrics.reset();
+      const output = await metrics.getMetrics();
+      expect(output).not.toMatch(/varken_collections_total\{[^}]*scheduler="sonarr_queue"[^}]*\} 1/);
+    });
+  });
+});

--- a/tests/core/PluginManager.test.ts
+++ b/tests/core/PluginManager.test.ts
@@ -1465,4 +1465,49 @@ describe('PluginManager', () => {
       expect(output.writtenPoints).toHaveLength(0);
     });
   });
+
+  describe('metrics integration', () => {
+    beforeEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should record write success in the attached Metrics instance', async () => {
+      const { Metrics } = await import('../../src/core/Metrics');
+      const metrics = new Metrics();
+
+      pluginManager.registerInputPlugin('sonarr', MockInputPlugin);
+      pluginManager.registerOutputPlugin('influxdb1', MockOutputPlugin);
+      await pluginManager.initializeFromConfig(minimalConfig);
+      pluginManager.setMetrics(metrics);
+
+      const validPoint: DataPoint = {
+        measurement: 'test',
+        tags: {},
+        fields: { v: 1 },
+        timestamp: new Date(),
+      };
+      await (
+        pluginManager as unknown as { writeToOutputs: (p: DataPoint[]) => Promise<void> }
+      ).writeToOutputs([validPoint]);
+
+      const output = await metrics.getMetrics();
+      expect(output).toMatch(
+        /varken_data_points_written_total\{[^}]*output="influxdb1"[^}]*status="success"[^}]*\} 1/
+      );
+    });
+
+    it('should record active plugin gauges after initializeFromConfig', async () => {
+      const { Metrics } = await import('../../src/core/Metrics');
+      const metrics = new Metrics();
+
+      pluginManager.setMetrics(metrics);
+      pluginManager.registerInputPlugin('sonarr', MockInputPlugin);
+      pluginManager.registerOutputPlugin('influxdb1', MockOutputPlugin);
+      await pluginManager.initializeFromConfig(minimalConfig);
+
+      const output = await metrics.getMetrics();
+      expect(output).toMatch(/varken_active_plugins\{[^}]*kind="input"[^}]*\} 1/);
+      expect(output).toMatch(/varken_active_plugins\{[^}]*kind="output"[^}]*\} 1/);
+    });
+  });
 });

--- a/tests/utils/env.test.ts
+++ b/tests/utils/env.test.ts
@@ -67,6 +67,15 @@ describe('validateEnvironment', () => {
     });
   });
 
+  describe('METRICS_ENABLED', () => {
+    it('rejects invalid boolean values', () => {
+      const result = validateEnvironment({ env: { METRICS_ENABLED: 'maybe' }, fsModule: makeFsMock() });
+      expect(result.errors).toEqual(
+        expect.arrayContaining([expect.stringContaining('METRICS_ENABLED="maybe"')])
+      );
+    });
+  });
+
   describe('LOG_LEVEL', () => {
     it('accepts standard winston levels', () => {
       for (const level of ['error', 'warn', 'info', 'debug']) {


### PR DESCRIPTION
## Description

Adds a Prometheus scrape endpoint at `GET /metrics` on the existing health server port. Provides visibility into collector runs, write throughput, errors, and circuit breaker states.

**New module `src/core/Metrics.ts`:**
Isolated `Registry` (not the prom-client default global) with:

| Metric                               | Type      | Labels              |
|--------------------------------------|-----------|---------------------|
| `varken_collections_total`           | counter   | scheduler, status   |
| `varken_collection_duration_seconds` | histogram | scheduler           |
| `varken_data_points_collected_total` | counter   | scheduler           |
| `varken_data_points_written_total`   | counter   | output, status      |
| `varken_scheduler_errors_total`      | counter   | scheduler           |
| `varken_circuit_breaker_state`       | gauge     | scheduler           |
| `varken_active_plugins`              | gauge     | kind (input/output) |

Plus standard Node.js process metrics (`collectDefaultMetrics`).

**Integration:**
- `PluginManager.setMetrics()` — records collection durations, data point counts, write success/failure, circuit breaker transitions
- `HealthServer.setMetrics()` — exposes `GET /metrics` with the Prometheus text content type
- `Orchestrator` constructor accepts `metricsEnabled` flag (default `true`), creates the `Metrics` instance, wires it through
- `METRICS_ENABLED` env var (validated in `env.ts`) toggles the feature
- Startup log now prints the metrics URL when enabled

**Testing:**
- 14 new tests for `Metrics` (output format, labels, state mapping, reset)
- 3 new tests for `/metrics` HTTP endpoint (success, 404 when disabled, content-type)
- 2 new tests for `PluginManager` ↔ `Metrics` integration
- 1 new test for `METRICS_ENABLED` env validation
- Coverage: `Metrics.ts` 100%, global 91.35% → **91.44%**

**New dependency:** `prom-client` (runtime).

## Type of change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [x] Dependencies update

## Checklist
- [x] I have tested my changes locally
- [x] I have added/updated tests if needed
- [x] Code coverage is maintained or improved (91.35% → 91.44%)
- [x] Lint passes (`npm run lint`)
- [x] Tests pass (`npm test`) — 591 passed (+20)

## Related

Part of Phase 7 (Observability & Resilience) in PLAN.md.