### PR TITLE
feat(utils): add RequestCache with TTL and in-flight deduplication

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -68,7 +68,7 @@ varken/
 │   └── utils/
 │       ├── http.ts                  # HTTP utilities, error classification
 │       └── index.ts
-├── tests/                           # 623 tests, 91% coverage
+├── tests/                           # 636 tests, 91% coverage
 │   ├── config/
 │   ├── core/
 │   ├── plugins/
@@ -228,7 +228,7 @@ interface ScheduleConfig {
 - [x] Main entry point (`index.ts`)
 - [x] Dockerfile (multi-stage, ~190MB)
 - [x] docker-compose.yml (Varken + InfluxDB 2.x + Grafana)
-- [x] Unit tests (623 tests passing)
+- [x] Unit tests (636 tests passing)
 - [x] CI/CD workflows (GitHub Actions)
 - [x] Codecov integration
 - [x] Documentation (README.md, CLAUDE.md)
@@ -444,7 +444,7 @@ interface ScheduleConfig {
 
 ## Test Coverage Summary
 
-> **Last updated**: 2026-04-24 | **Global coverage**: 90.83% | **Tests**: 623 passing
+> **Last updated**: 2026-04-24 | **Global coverage**: 91.09% | **Tests**: 636 passing
 
 | File | Coverage | Target | Status | Notes |
 |------|----------|--------|--------|-------|
@@ -460,9 +460,10 @@ interface ScheduleConfig {
 | `src/utils/http.ts` | 70.65% | 85% | ⚠️ | Interceptor callbacks need integration tests |
 | `src/utils/env.ts` | 100% | 90% | ✅ | Added in Phase 11 (Env Validation) |
 | `src/utils/errors.ts` | 91.04% | 90% | ✅ | Added in Phase 11 (Better Error Messages) |
+| `src/utils/RequestCache.ts` | 100% | 90% | ✅ | Added in Phase 11 (Request Cache) |
 | `src/plugins/inputs/SonarrPlugin.ts` | 91.89% | 90% | ✅ | Improved via safeFetch refactor |
 | `src/plugins/inputs/RadarrPlugin.ts` | 98.07% | 90% | ✅ | Improved via safeFetch refactor |
-| `src/plugins/inputs/TautulliPlugin.ts` | 93.56% | 90% | ✅ | GeoIP via Tautulli API |
+| `src/plugins/inputs/TautulliPlugin.ts` | 95.03% | 90% | ✅ | Uses `RequestCache` for GeoIP |
 | `src/plugins/inputs/OmbiPlugin.ts` | 93.67% | 90% | ✅ | Improved via safeFetch refactor |
 | `src/plugins/inputs/OverseerrPlugin.ts` | 91.17% | 90% | ✅ | Improved via safeFetch refactor |
 | `src/plugins/inputs/ReadarrPlugin.ts` | 98.03% | 90% | ✅ | Improved via safeFetch refactor |
@@ -541,7 +542,7 @@ DataPoint (internal format)
 | Structured logging | ~4h | Debugging |
 | ~~Dry-run mode~~ | ~~✅~~ | ~~`--dry-run` / `DRY_RUN=true`~~ |
 | ~~Better error messages~~ | ~~✅~~ | ~~UX — `src/utils/errors.ts`~~ |
-| ~~Improve test coverage~~ | ~~✅~~ | ~~Quality - Global 90.83%~~ |
+| ~~Improve test coverage~~ | ~~✅~~ | ~~Quality - Global 91.09%~~ |
 
 ### Low Priority
 | Item | Effort | Impact |

--- a/src/plugins/inputs/TautulliPlugin.ts
+++ b/src/plugins/inputs/TautulliPlugin.ts
@@ -1,4 +1,5 @@
 import { BaseInputPlugin } from './BaseInputPlugin';
+import { RequestCache } from '../../utils/RequestCache';
 import type { PluginMetadata, DataPoint, ScheduleConfig } from '../../types/plugin.types';
 import type {
   TautulliConfig,
@@ -39,7 +40,10 @@ export class TautulliPlugin extends BaseInputPlugin<TautulliConfig> {
   private static readonly GEOIP_CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
   private static readonly GEOIP_CACHE_MAX_SIZE = 1000;
 
-  private geoipCache = new Map<string, { data: GeoIPInfo | null; timestamp: number }>();
+  private geoipCache = new RequestCache<GeoIPInfo | null>({
+    ttlMs: TautulliPlugin.GEOIP_CACHE_TTL_MS,
+    maxSize: TautulliPlugin.GEOIP_CACHE_MAX_SIZE,
+  });
 
   readonly metadata: PluginMetadata = {
     name: 'Tautulli',
@@ -199,51 +203,35 @@ export class TautulliPlugin extends BaseInputPlugin<TautulliConfig> {
    * Perform GeoIP lookup using Tautulli API
    */
   private async geoipLookup(ip: string): Promise<GeoIPInfo | null> {
-    const cached = this.geoipCache.get(ip);
-    if (cached && Date.now() - cached.timestamp < TautulliPlugin.GEOIP_CACHE_TTL_MS) {
-      return cached.data;
-    }
+    return this.geoipCache.getOrFetch(ip, async () => {
+      try {
+        const response = await this.httpGet<TautulliApiResponse<TautulliGeoIPResponse>>(
+          '/api/v2',
+          {
+            apikey: this.config.apiKey,
+            cmd: 'get_geoip_lookup',
+            ip_address: ip,
+          }
+        );
 
-    // Evict oldest entry if cache is full
-    if (this.geoipCache.size >= TautulliPlugin.GEOIP_CACHE_MAX_SIZE) {
-      const oldestKey = this.geoipCache.keys().next().value;
-      if (oldestKey !== undefined) {
-        this.geoipCache.delete(oldestKey);
-      }
-    }
-
-    try {
-      const response = await this.httpGet<TautulliApiResponse<TautulliGeoIPResponse>>(
-        '/api/v2',
-        {
-          apikey: this.config.apiKey,
-          cmd: 'get_geoip_lookup',
-          ip_address: ip,
+        if (response?.response?.result !== 'success' || !response?.response?.data) {
+          return null;
         }
-      );
 
-      if (response?.response?.result !== 'success' || !response?.response?.data) {
-        this.geoipCache.set(ip, { data: null, timestamp: Date.now() });
+        const data = response.response.data;
+        return {
+          city: data.city || '',
+          region: data.region || '',
+          country: data.country || '',
+          latitude: data.latitude || 0,
+          longitude: data.longitude || 0,
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        this.logger.debug(`GeoIP lookup failed for ${this.maskIp(ip)}: ${message}`);
         return null;
       }
-
-      const data = response.response.data;
-      const geoInfo: GeoIPInfo = {
-        city: data.city || '',
-        region: data.region || '',
-        country: data.country || '',
-        latitude: data.latitude || 0,
-        longitude: data.longitude || 0,
-      };
-
-      this.geoipCache.set(ip, { data: geoInfo, timestamp: Date.now() });
-      return geoInfo;
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Unknown error';
-      this.logger.debug(`GeoIP lookup failed for ${this.maskIp(ip)}: ${message}`);
-      this.geoipCache.set(ip, { data: null, timestamp: Date.now() });
-      return null;
-    }
+    });
   }
 
   /**

--- a/src/utils/RequestCache.ts
+++ b/src/utils/RequestCache.ts
@@ -1,0 +1,107 @@
+/**
+ * In-memory cache with TTL and in-flight request deduplication.
+ *
+ * Two behaviors on top of a plain `Map`:
+ * 1. **TTL** — entries expire after `ttlMs` and are evicted lazily on access.
+ * 2. **Deduplication** — concurrent calls to `getOrFetch()` with the same key
+ *    share a single in-flight promise, so the underlying fetcher runs once
+ *    even under racey access patterns (e.g. a health check and a scheduler
+ *    asking for the same resource).
+ *
+ * `maxSize` caps memory via simple FIFO eviction (insertion order of the Map).
+ * Entries are evicted when the cache is full and a new key is inserted.
+ */
+export interface RequestCacheOptions {
+  ttlMs: number;
+  maxSize?: number;
+}
+
+interface CacheEntry<V> {
+  value: V;
+  expiresAt: number;
+}
+
+export class RequestCache<V = unknown> {
+  private readonly ttlMs: number;
+  private readonly maxSize: number;
+  private readonly store = new Map<string, CacheEntry<V>>();
+  private readonly inflight = new Map<string, Promise<V>>();
+
+  constructor(options: RequestCacheOptions) {
+    this.ttlMs = options.ttlMs;
+    this.maxSize = options.maxSize ?? Infinity;
+  }
+
+  /**
+   * Look up a fresh value for `key`, running `fetcher` only if there is no
+   * usable cached entry and no in-flight request. Multiple concurrent callers
+   * with the same key share the same promise.
+   */
+  async getOrFetch(key: string, fetcher: () => Promise<V>): Promise<V> {
+    const fresh = this.peek(key);
+    if (fresh !== undefined) {
+      return fresh;
+    }
+
+    const existing = this.inflight.get(key);
+    if (existing) {
+      return existing;
+    }
+
+    const pending = (async (): Promise<V> => {
+      try {
+        const value = await fetcher();
+        this.set(key, value);
+        return value;
+      } finally {
+        this.inflight.delete(key);
+      }
+    })();
+
+    this.inflight.set(key, pending);
+    return pending;
+  }
+
+  /**
+   * Return the cached value if present and not expired; undefined otherwise.
+   * Expired entries are evicted as a side effect.
+   */
+  peek(key: string): V | undefined {
+    const entry = this.store.get(key);
+    if (!entry) {
+      return undefined;
+    }
+    if (entry.expiresAt <= Date.now()) {
+      this.store.delete(key);
+      return undefined;
+    }
+    return entry.value;
+  }
+
+  /**
+   * Overwrite the cached value for `key` (refreshes TTL).
+   */
+  set(key: string, value: V): void {
+    if (this.store.size >= this.maxSize && !this.store.has(key)) {
+      const oldest = this.store.keys().next().value;
+      if (oldest !== undefined) {
+        this.store.delete(oldest);
+      }
+    }
+    this.store.set(key, { value, expiresAt: Date.now() + this.ttlMs });
+  }
+
+  delete(key: string): void {
+    this.store.delete(key);
+    this.inflight.delete(key);
+  }
+
+  clear(): void {
+    this.store.clear();
+    this.inflight.clear();
+  }
+
+  get size(): number {
+    return this.store.size;
+  }
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -18,5 +18,9 @@ export type { EnvValidationResult, EnvValidationOptions } from './env';
 export { explainError, formatHelpfulError } from './errors';
 export type { ErrorContext, ExplainedError } from './errors';
 
+// Request cache with TTL + deduplication
+export { RequestCache } from './RequestCache';
+export type { RequestCacheOptions } from './RequestCache';
+
 // Re-export types
 export type { HttpClientConfig, RetryConfig } from '../types/http.types';

--- a/tests/utils/RequestCache.test.ts
+++ b/tests/utils/RequestCache.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { RequestCache } from '../../src/utils/RequestCache';
+
+describe('RequestCache', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('getOrFetch', () => {
+    it('calls the fetcher on a cache miss and caches the result', async () => {
+      const cache = new RequestCache<number>({ ttlMs: 1000 });
+      const fetcher = vi.fn().mockResolvedValue(42);
+
+      await expect(cache.getOrFetch('a', fetcher)).resolves.toBe(42);
+      expect(fetcher).toHaveBeenCalledTimes(1);
+      expect(cache.size).toBe(1);
+    });
+
+    it('returns the cached value on a subsequent call without re-running the fetcher', async () => {
+      const cache = new RequestCache<number>({ ttlMs: 1000 });
+      const fetcher = vi.fn().mockResolvedValue(1);
+
+      await cache.getOrFetch('a', fetcher);
+      await cache.getOrFetch('a', fetcher);
+
+      expect(fetcher).toHaveBeenCalledTimes(1);
+    });
+
+    it('refetches after the TTL expires', async () => {
+      const cache = new RequestCache<number>({ ttlMs: 100 });
+      const fetcher = vi.fn().mockResolvedValue(1);
+
+      await cache.getOrFetch('a', fetcher);
+      await vi.advanceTimersByTimeAsync(150);
+      await cache.getOrFetch('a', fetcher);
+
+      expect(fetcher).toHaveBeenCalledTimes(2);
+    });
+
+    it('caches null values (not just truthy ones)', async () => {
+      const cache = new RequestCache<string | null>({ ttlMs: 1000 });
+      const fetcher = vi.fn().mockResolvedValue(null);
+
+      await cache.getOrFetch('a', fetcher);
+      await cache.getOrFetch('a', fetcher);
+
+      expect(fetcher).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('deduplication', () => {
+    it('only runs the fetcher once for concurrent calls with the same key', async () => {
+      const cache = new RequestCache<number>({ ttlMs: 1000 });
+      let resolve: (value: number) => void = () => {};
+      const fetcher = vi.fn(
+        () =>
+          new Promise<number>((r) => {
+            resolve = r;
+          })
+      );
+
+      const p1 = cache.getOrFetch('a', fetcher);
+      const p2 = cache.getOrFetch('a', fetcher);
+      const p3 = cache.getOrFetch('a', fetcher);
+
+      expect(fetcher).toHaveBeenCalledTimes(1);
+
+      resolve(7);
+      await expect(Promise.all([p1, p2, p3])).resolves.toEqual([7, 7, 7]);
+    });
+
+    it('runs fetchers in parallel for different keys', async () => {
+      const cache = new RequestCache<number>({ ttlMs: 1000 });
+      const fetcher = vi.fn(async (key: string) => (key === 'a' ? 1 : 2));
+
+      const [a, b] = await Promise.all([
+        cache.getOrFetch('a', () => fetcher('a')),
+        cache.getOrFetch('b', () => fetcher('b')),
+      ]);
+
+      expect(a).toBe(1);
+      expect(b).toBe(2);
+      expect(fetcher).toHaveBeenCalledTimes(2);
+    });
+
+    it('releases the in-flight slot when the fetcher throws', async () => {
+      const cache = new RequestCache<number>({ ttlMs: 1000 });
+      const fetcher = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockResolvedValue(9);
+
+      await expect(cache.getOrFetch('a', fetcher)).rejects.toThrow('boom');
+      // Second call must be able to retry (in-flight slot cleared)
+      await expect(cache.getOrFetch('a', fetcher)).resolves.toBe(9);
+      expect(fetcher).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('maxSize eviction', () => {
+    it('evicts the oldest entry when the cache is full', async () => {
+      const cache = new RequestCache<number>({ ttlMs: 10_000, maxSize: 2 });
+
+      await cache.getOrFetch('a', async () => 1);
+      await cache.getOrFetch('b', async () => 2);
+      await cache.getOrFetch('c', async () => 3);
+
+      expect(cache.size).toBe(2);
+      expect(cache.peek('a')).toBeUndefined();
+      expect(cache.peek('b')).toBe(2);
+      expect(cache.peek('c')).toBe(3);
+    });
+
+    it('does not evict when overwriting an existing key', async () => {
+      const cache = new RequestCache<number>({ ttlMs: 10_000, maxSize: 2 });
+      await cache.getOrFetch('a', async () => 1);
+      await cache.getOrFetch('b', async () => 2);
+
+      cache.set('a', 99);
+
+      expect(cache.size).toBe(2);
+      expect(cache.peek('a')).toBe(99);
+      expect(cache.peek('b')).toBe(2);
+    });
+  });
+
+  describe('peek / delete / clear', () => {
+    it('peek returns undefined for missing keys', () => {
+      const cache = new RequestCache<number>({ ttlMs: 1000 });
+      expect(cache.peek('missing')).toBeUndefined();
+    });
+
+    it('peek evicts and returns undefined for expired entries', async () => {
+      const cache = new RequestCache<number>({ ttlMs: 100 });
+      cache.set('a', 1);
+      await vi.advanceTimersByTimeAsync(150);
+
+      expect(cache.peek('a')).toBeUndefined();
+      expect(cache.size).toBe(0);
+    });
+
+    it('delete removes an entry', () => {
+      const cache = new RequestCache<number>({ ttlMs: 1000 });
+      cache.set('a', 1);
+      cache.delete('a');
+      expect(cache.peek('a')).toBeUndefined();
+    });
+
+    it('clear empties the cache', () => {
+      const cache = new RequestCache<number>({ ttlMs: 1000 });
+      cache.set('a', 1);
+      cache.set('b', 2);
+      cache.clear();
+      expect(cache.size).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Introduces a generic `RequestCache<V>` utility for TTL-based caching with automatic in-flight request deduplication, and uses it to replace the hand-rolled GeoIP cache in `TautulliPlugin`.

### New module `src/utils/RequestCache.ts`

- **TTL** with lazy expiration (evicted on access)
- **FIFO eviction** when `maxSize` is hit
- **In-flight deduplication**: concurrent `getOrFetch()` calls for the same key share a single promise, so the fetcher only runs once under race conditions (e.g. a health check and a scheduler asking for the same resource at the same time)
- **Negative caching supported**: a fetcher returning `null` is cached just like any other value
- **Failure isolation**: if the fetcher throws, the in-flight slot is released so the next call can retry cleanly

API:
```ts
const cache = new RequestCache<GeoIPInfo | null>({ ttlMs: 24 * 3600 * 1000, maxSize: 1000 });
const geo = await cache.getOrFetch(ip, () => lookup(ip));
```

### `TautulliPlugin` refactor

Replaces ~30 lines of hand-rolled cache code (manual TTL check, manual size eviction, separate success/null paths) with 5 lines of `cache.getOrFetch(ip, ...)`. The fetcher still catches errors and returns `null` (same negative-caching behavior as before).

Coverage impact: `TautulliPlugin` 93.56% → **95.03%** (fewer conditional branches).

### Testing

- **13 new tests** for `RequestCache` covering: cache hit/miss, TTL expiration, null caching, concurrent dedup, per-key parallelism, in-flight slot cleanup on error, FIFO eviction, overwriting without eviction, `peek`/`delete`/`clear`
- Existing 46 Tautulli tests still pass unchanged
- Coverage: `RequestCache.ts` 100%, global 90.83% → **91.09%**

### Why not broader integration yet

Other plugins don't currently have obvious duplication of requests between schedules. The primary payoff (Tautulli GeoIP) is taken; future plugins can opt in by importing `RequestCache` from `src/utils`. Not forcing it on every plugin keeps the refactor surface small.

## Type of change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring
- [ ] Dependencies update

## Checklist
- [x] I have tested my changes locally
- [x] I have added/updated tests if needed (+13)
- [x] Code coverage is maintained or improved (90.83% → 91.09%)
- [x] Lint passes (`npm run lint`)
- [x] Tests pass (`npm test`) — 636 passed

## Related

Part of Phase 11 (Developer Experience) in PLAN.md.