### PR TITLE
test: add shared test fixtures in tests/fixtures/

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -68,7 +68,7 @@ varken/
 │   └── utils/
 │       ├── http.ts                  # HTTP utilities, error classification
 │       └── index.ts
-├── tests/                           # 640 tests, 91% coverage
+├── tests/                           # 648 tests, 91% coverage
 │   ├── config/
 │   ├── core/
 │   ├── plugins/
@@ -228,7 +228,7 @@ interface ScheduleConfig {
 - [x] Main entry point (`index.ts`)
 - [x] Dockerfile (multi-stage, ~190MB)
 - [x] docker-compose.yml (Varken + InfluxDB 2.x + Grafana)
-- [x] Unit tests (640 tests passing)
+- [x] Unit tests (648 tests passing)
 - [x] CI/CD workflows (GitHub Actions)
 - [x] Codecov integration
 - [x] Documentation (README.md, CLAUDE.md)
@@ -392,12 +392,14 @@ interface ScheduleConfig {
   - Wraps collector operations with error logging + re-throw
   - All 9 input plugins refactored to use it (21 try/catch blocks removed)
 
-#### Test Fixtures
-- [ ] Create shared test fixtures in `tests/fixtures/`
-  - `createMockHttpClient(responses)`
-  - `createMockConfig(overrides)`
-  - Reduce duplication in plugin tests
-  - Effort: ~2h
+#### Test Fixtures ✅
+- [x] Create shared test fixtures in `tests/fixtures/`
+  - `createMockHttpClient()` — fresh axios-like client shape (get/post/defaults/interceptors)
+  - `createMockAxios(client?)` — `vi.mock('axios', …)` factory
+  - `createMockVarkenConfig(overrides)` — minimal valid `VarkenConfig` passing Zod validation
+  - `createMockGlobalConfig(overrides)` — production-like global defaults
+  - `loggerMock()` — factory for `vi.mock('<path>/core/Logger', …)` including `createLogger` and `withContext`
+  - `SonarrPlugin.test.ts` refactored as usage demo
 
 #### Graceful Plugin Skipping ✅
 - [x] Make output plugin failures non-fatal at startup
@@ -445,7 +447,7 @@ interface ScheduleConfig {
 
 ## Test Coverage Summary
 
-> **Last updated**: 2026-04-24 | **Global coverage**: 91.15% | **Tests**: 640 passing
+> **Last updated**: 2026-04-24 | **Global coverage**: 91.15% | **Tests**: 648 passing
 
 | File | Coverage | Target | Status | Notes |
 |------|----------|--------|--------|-------|

--- a/tests/fixtures/config.ts
+++ b/tests/fixtures/config.ts
@@ -1,0 +1,49 @@
+import type { VarkenConfig, GlobalConfig } from '../../src/config/schemas/config.schema';
+
+export function createMockGlobalConfig(overrides: Partial<GlobalConfig> = {}): GlobalConfig {
+  return {
+    httpTimeoutMs: 30000,
+    healthCheckTimeoutMs: 5000,
+    collectorTimeoutMs: 60000,
+    paginationPageSize: 250,
+    maxPaginationRecords: 10000,
+    ...overrides,
+  };
+}
+
+/**
+ * Minimal valid `VarkenConfig` suitable for unit tests that need to drive
+ * PluginManager / Orchestrator end to end.
+ *
+ * Override any top-level slice via `overrides`; everything else gets sensible
+ * defaults (one Sonarr input with a `queue` schedule, one InfluxDB1 output).
+ */
+export function createMockVarkenConfig(overrides: Partial<VarkenConfig> = {}): VarkenConfig {
+  return {
+    global: createMockGlobalConfig(),
+    outputs: {
+      influxdb1: {
+        url: 'localhost',
+        port: 8086,
+        username: 'root',
+        password: 'root',
+        database: 'varken',
+        ssl: false,
+        verifySsl: false,
+      },
+    },
+    inputs: {
+      sonarr: [
+        {
+          id: 1,
+          url: 'http://localhost:8989',
+          apiKey: 'test-key',
+          verifySsl: false,
+          queue: { enabled: true, intervalSeconds: 30 },
+          calendar: { enabled: false, intervalSeconds: 300, futureDays: 7, missingDays: 30 },
+        },
+      ],
+    },
+    ...overrides,
+  };
+}

--- a/tests/fixtures/fixtures.test.ts
+++ b/tests/fixtures/fixtures.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { VarkenConfigSchema } from '../../src/config/schemas/config.schema';
+import {
+  createMockHttpClient,
+  createMockAxios,
+  createMockVarkenConfig,
+  createMockGlobalConfig,
+  loggerMock,
+} from './index';
+
+describe('test fixtures', () => {
+  describe('createMockHttpClient', () => {
+    it('returns an axios-like client with fresh spies per invocation', () => {
+      const a = createMockHttpClient();
+      const b = createMockHttpClient();
+
+      expect(a.get).not.toBe(b.get);
+      expect(a.post).not.toBe(b.post);
+      expect(a.defaults.headers.common).toEqual({});
+      expect(typeof a.interceptors.request.use).toBe('function');
+    });
+  });
+
+  describe('createMockAxios', () => {
+    it('wraps a client and exposes default.create()', () => {
+      const client = createMockHttpClient();
+      const axios = createMockAxios(client);
+
+      expect(axios.default.create).toBeDefined();
+      expect(axios.default.create()).toBe(client);
+    });
+  });
+
+  describe('createMockVarkenConfig', () => {
+    it('returns a config that passes schema validation as-is', () => {
+      const config = createMockVarkenConfig();
+      const result = VarkenConfigSchema.safeParse(config);
+      expect(result.success).toBe(true);
+    });
+
+    it('applies top-level overrides', () => {
+      const config = createMockVarkenConfig({
+        outputs: {
+          influxdb2: {
+            url: 'localhost',
+            port: 8086,
+            token: 't',
+            org: 'o',
+            bucket: 'b',
+            ssl: false,
+            verifySsl: false,
+          },
+        },
+      });
+      expect(config.outputs.influxdb2).toBeDefined();
+      expect(config.outputs.influxdb1).toBeUndefined();
+    });
+  });
+
+  describe('createMockGlobalConfig', () => {
+    it('uses production-like defaults', () => {
+      const g = createMockGlobalConfig();
+      expect(g.httpTimeoutMs).toBe(30000);
+      expect(g.collectorTimeoutMs).toBe(60000);
+    });
+
+    it('accepts partial overrides', () => {
+      const g = createMockGlobalConfig({ httpTimeoutMs: 1000 });
+      expect(g.httpTimeoutMs).toBe(1000);
+      expect(g.healthCheckTimeoutMs).toBe(5000);
+    });
+  });
+
+  describe('loggerMock', () => {
+    it('exposes createLogger with info/debug/warn/error spies', () => {
+      const mock = loggerMock();
+      const logger = mock.createLogger();
+      expect(typeof logger.info).toBe('function');
+      expect(typeof logger.debug).toBe('function');
+      expect(typeof logger.warn).toBe('function');
+      expect(typeof logger.error).toBe('function');
+    });
+
+    it('withContext returns the logger unchanged (pass-through)', () => {
+      const mock = loggerMock();
+      const logger = mock.createLogger();
+      expect(mock.withContext(logger, { pluginId: 1 })).toBe(logger);
+    });
+  });
+});

--- a/tests/fixtures/http.ts
+++ b/tests/fixtures/http.ts
@@ -1,0 +1,41 @@
+import { vi, type Mock } from 'vitest';
+
+export interface MockHttpClient {
+  get: Mock;
+  post: Mock;
+  defaults: { headers: { common: Record<string, string> } };
+  interceptors: {
+    request: { use: Mock };
+    response: { use: Mock };
+  };
+}
+
+/**
+ * Shape of a minimal axios-like HTTP client used across plugin tests.
+ * Each call returns a fresh object so mocks don't leak between tests.
+ */
+export function createMockHttpClient(): MockHttpClient {
+  return {
+    get: vi.fn(),
+    post: vi.fn(),
+    defaults: { headers: { common: {} } },
+    interceptors: {
+      request: { use: vi.fn() },
+      response: { use: vi.fn() },
+    },
+  };
+}
+
+/**
+ * Mock factory for `vi.mock('axios', …)`. Returns a getter so Vitest can read
+ * it lazily when the module is imported under test.
+ */
+export function createMockAxios(client: MockHttpClient = createMockHttpClient()): {
+  default: { create: Mock };
+} {
+  return {
+    default: {
+      create: vi.fn(() => client),
+    },
+  };
+}

--- a/tests/fixtures/index.ts
+++ b/tests/fixtures/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Shared test fixtures.
+ *
+ * Keep fixtures small and composable. Prefer returning plain objects or
+ * functions over building deep mock hierarchies — tests should remain readable.
+ */
+
+export { createMockHttpClient, createMockAxios, type MockHttpClient } from './http';
+export { createMockVarkenConfig, createMockGlobalConfig } from './config';
+export { loggerMock } from './logger';

--- a/tests/fixtures/logger.ts
+++ b/tests/fixtures/logger.ts
@@ -1,0 +1,21 @@
+import { vi } from 'vitest';
+
+/**
+ * Ready-made factory for `vi.mock('<path>/core/Logger', loggerMock)`.
+ *
+ * Returns a fresh set of spy functions each time so mock assertions don't
+ * leak between test files. `withContext` is a pass-through — it returns the
+ * same logger so tagged loggers behave identically to the base one in tests.
+ */
+export const loggerMock = (): {
+  createLogger: () => Record<'info' | 'debug' | 'warn' | 'error', ReturnType<typeof vi.fn>>;
+  withContext: (logger: unknown) => unknown;
+} => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+  withContext: (logger: unknown) => logger,
+});

--- a/tests/plugins/inputs/SonarrPlugin.test.ts
+++ b/tests/plugins/inputs/SonarrPlugin.test.ts
@@ -2,35 +2,22 @@ import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
 import { SonarrPlugin } from '../../../src/plugins/inputs/SonarrPlugin';
 import { SonarrConfig } from '../../../src/types/inputs/sonarr.types';
 import axios from 'axios';
+import { createMockHttpClient, type MockHttpClient } from '../../fixtures/http';
 
-// Mock the logger
-vi.mock('../../../src/core/Logger', () => ({
-  createLogger: () => ({
-    info: vi.fn(),
-    debug: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  }),
-  withContext: (logger: unknown) => logger,
-}));
+vi.mock('../../../src/core/Logger', async () => {
+  const { loggerMock: mock } = await import('../../fixtures/logger');
+  return mock();
+});
 
-// Mock axios
 vi.mock('axios', () => ({
   default: {
-    create: vi.fn(() => ({
-      get: vi.fn(),
-      defaults: {
-        headers: {
-          common: {},
-        },
-      },
-    })),
+    create: vi.fn(),
   },
 }));
 
 describe('SonarrPlugin', () => {
   let plugin: SonarrPlugin;
-  let mockHttpClient: { get: Mock; defaults: { headers: { common: Record<string, string> } } };
+  let mockHttpClient: MockHttpClient;
 
   const testConfig: SonarrConfig = {
     id: 1,
@@ -52,19 +39,7 @@ describe('SonarrPlugin', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     plugin = new SonarrPlugin();
-
-    mockHttpClient = {
-      get: vi.fn(),
-      defaults: {
-        headers: {
-          common: {},
-        },
-      },
-      interceptors: {
-        response: { use: vi.fn() },
-        request: { use: vi.fn() },
-      },
-    };
+    mockHttpClient = createMockHttpClient();
     (axios.create as Mock).mockReturnValue(mockHttpClient);
   });
 


### PR DESCRIPTION
## Description

Adds a small set of reusable test fixtures that encode the recurring boilerplate in plugin tests, and demonstrates their use by refactoring `SonarrPlugin.test.ts`.

### New `tests/fixtures/` module

| Export                        | Purpose                                                              |
|-------------------------------|----------------------------------------------------------------------|
| `createMockHttpClient()`      | Fresh axios-like client (`get`/`post`/`defaults`/`interceptors`)     |
| `createMockAxios(client?)`    | Factory for `vi.mock('axios', …)` that returns the client via `default.create()` |
| `createMockVarkenConfig(overrides?)` | Minimal valid `VarkenConfig` (passes Zod validation unmodified) |
| `createMockGlobalConfig(overrides?)` | Production-like `GlobalConfig` defaults                      |
| `loggerMock()`                | Factory for `vi.mock('<path>/core/Logger', …)`, returns `createLogger` + `withContext` stubs |

### Usage pattern

```ts
import { createMockHttpClient, type MockHttpClient } from '../../fixtures/http';

vi.mock('../../../src/core/Logger', async () => {
  const { loggerMock: mock } = await import('../../fixtures/logger');
  return mock();
});

beforeEach(() => {
  mockHttpClient = createMockHttpClient();
  (axios.create as Mock).mockReturnValue(mockHttpClient);
});
```

Note the async `vi.mock` factory for `loggerMock` — Vitest hoists `vi.mock` before imports, so the fixture has to be pulled in lazily. `createMockHttpClient` has no hoisting concern because it's called inside `beforeEach`.

### Demo refactor

`SonarrPlugin.test.ts` now uses the fixtures — ~18 lines of mock setup removed, behavior identical (all 14 tests still pass). Other plugin tests are untouched by design; the fixtures are opt-in so adopting them is a follow-up per-test choice rather than a big-bang refactor.

### Testing

- `tests/fixtures/fixtures.test.ts` — 8 unit tests validating every fixture (including schema round-trip for `createMockVarkenConfig`)
- 648 tests total pass (was 640)

## Type of change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring
- [ ] Dependencies update

## Checklist
- [x] I have tested my changes locally
- [x] I have added/updated tests if needed (+8)
- [x] Code coverage is maintained or improved
- [x] Lint passes (`npm run lint`)
- [x] Tests pass (`npm test`) — 648 passed

## Related

Part of Phase 12 (Code Quality) in PLAN.md — completes the phase (BaseInputPlugin improvements ✅, Test Fixtures ✅, Graceful Plugin Skipping ✅).