### PR TITLE
feat(outputs): add QuestDB output plugin

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -68,7 +68,7 @@ varken/
 │   └── utils/
 │       ├── http.ts                  # HTTP utilities, error classification
 │       └── index.ts
-├── tests/                           # 648 tests, 91% coverage
+├── tests/                           # 660 tests, 91% coverage
 │   ├── config/
 │   ├── core/
 │   ├── plugins/
@@ -228,7 +228,7 @@ interface ScheduleConfig {
 - [x] Main entry point (`index.ts`)
 - [x] Dockerfile (multi-stage, ~190MB)
 - [x] docker-compose.yml (Varken + InfluxDB 2.x + Grafana)
-- [x] Unit tests (648 tests passing)
+- [x] Unit tests (660 tests passing)
 - [x] CI/CD workflows (GitHub Actions)
 - [x] Codecov integration
 - [x] Documentation (README.md, CLAUDE.md)
@@ -277,11 +277,12 @@ interface ScheduleConfig {
   - Reuses existing Line Protocol code from BaseOutputPlugin
   - Uses `axios` (already installed)
 
-#### QuestDB
-- [ ] `QuestDBPlugin` - InfluxDB line protocol (ILP) support
-  - HTTP or native TCP
-  - Uses `axios` (already installed)
-  - Effort: ~6h
+#### QuestDB ✅
+- [x] `QuestDBPlugin` - InfluxDB line protocol (ILP) support
+  - `POST /write` with ILP body (HTTP transport on default port 9000)
+  - Health check via `GET /exec?query=SELECT 1` to validate the full REST layer (not just static HTTP)
+  - Uses `axios` (already installed); reuses `toLineProtocolBatch()` from BaseOutputPlugin
+  - Native TCP (port 9009) left as a future enhancement if performance requires it
 
 #### TimescaleDB
 - [ ] `TimescaleDBPlugin` - PostgreSQL with hypertables
@@ -447,7 +448,7 @@ interface ScheduleConfig {
 
 ## Test Coverage Summary
 
-> **Last updated**: 2026-04-24 | **Global coverage**: 91.15% | **Tests**: 648 passing
+> **Last updated**: 2026-04-24 | **Global coverage**: 91.23% | **Tests**: 660 passing
 
 | File | Coverage | Target | Status | Notes |
 |------|----------|--------|--------|-------|
@@ -476,6 +477,7 @@ interface ScheduleConfig {
 | `src/plugins/outputs/InfluxDB1Plugin.ts` | 100% | 90% | ✅ | |
 | `src/plugins/outputs/InfluxDB2Plugin.ts` | 93.33% | 90% | ✅ | |
 | `src/plugins/outputs/VictoriaMetricsPlugin.ts` | 100% | 90% | ✅ | Added in Phase 8 |
+| `src/plugins/outputs/QuestDBPlugin.ts` | 100% | 90% | ✅ | Added in Phase 8 |
 | `src/plugins/inputs/BaseInputPlugin.ts` | 89.18% | 90% | ⚠️ | |
 | `src/plugins/outputs/BaseOutputPlugin.ts` | 100% | 90% | ✅ | |
 
@@ -507,7 +509,7 @@ interface ScheduleConfig {
 | **InfluxDB1Plugin** | HTTP API v1 | InfluxDB 1.x - Legacy, InfluxQL | ✅ |
 | **InfluxDB2Plugin** | HTTP API v2 | InfluxDB 2.x - Flux, Buckets, Tokens | ✅ |
 | **VictoriaMetricsPlugin** | InfluxDB line protocol | High performance, compatible | ✅ |
-| **QuestDBPlugin** | ILP over TCP/HTTP | Time-series SQL, fast ingestion | 🚧 Types ready |
+| **QuestDBPlugin** | ILP over HTTP | Time-series SQL, fast ingestion | ✅ |
 | **TimescaleDBPlugin** | PostgreSQL | Hypertables, standard SQL | 🚧 Types ready |
 
 ### Protocol Compatibility
@@ -541,7 +543,7 @@ DataPoint (internal format)
 |------|--------|--------|
 | ~~Prometheus metrics~~ | ~~✅~~ | ~~Observability~~ |
 | ~~Config hot-reload~~ | ~~✅~~ | ~~Operations — via `CONFIG_WATCH=true`~~ |
-| QuestDB, TimescaleDB outputs | ~14h | More DB options |
+| TimescaleDB output | ~8h | More DB options |
 | ~~Structured logging~~ | ~~✅~~ | ~~`LOG_FORMAT=json` + `withContext()`~~ |
 | ~~Dry-run mode~~ | ~~✅~~ | ~~`--dry-run` / `DRY_RUN=true`~~ |
 | ~~Better error messages~~ | ~~✅~~ | ~~UX — `src/utils/errors.ts`~~ |

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Built with TypeScript, Node.js, and a plugin-based architecture with scheduled d
 ### Data Collection
 
 - **Multiple data sources** — Sonarr, Radarr, Readarr, Lidarr, Tautulli, Ombi, Overseerr, Prowlarr, Bazarr
-- **Multiple outputs** — InfluxDB 1.x, InfluxDB 2.x, VictoriaMetrics
+- **Multiple outputs** — InfluxDB 1.x, InfluxDB 2.x, VictoriaMetrics, QuestDB
 - **Multi-instance support** — connect multiple instances of each service
 - **GeoIP mapping** — automatic geolocation of streaming sessions via Tautulli API (no external license required)
 
@@ -85,7 +85,7 @@ Built with TypeScript, Node.js, and a plugin-based architecture with scheduled d
 | **InfluxDB 2.x** (recommended) | ✅          |
 | **InfluxDB 1.x** (legacy)      | ✅          |
 | **VictoriaMetrics**            | ✅          |
-| **QuestDB**                    | 🚧 Planned |
+| **QuestDB**                    | ✅          |
 | **TimescaleDB**                | 🚧 Planned |
 
 ## Installation
@@ -212,6 +212,10 @@ outputs:
   # VictoriaMetrics (InfluxDB line protocol compatible)
   victoriametrics:
     url: "http://victoriametrics:8428"
+
+  # QuestDB (ILP over HTTP on port 9000)
+  questdb:
+    url: "http://questdb:9000"
 ```
 
 See [`config/varken.example.yaml`](config/varken.example.yaml) for the complete list of supported options.

--- a/src/plugins/outputs/QuestDBPlugin.ts
+++ b/src/plugins/outputs/QuestDBPlugin.ts
@@ -1,0 +1,80 @@
+import type { AxiosInstance } from 'axios';
+import type { z } from 'zod';
+import { BaseOutputPlugin } from './BaseOutputPlugin';
+import type { DataPoint, PluginMetadata } from '../../types/plugin.types';
+import type { QuestDBConfigSchema } from '../../config/schemas/config.schema';
+import { createHttpClient, withTimeout } from '../../utils/http';
+import { formatHelpfulError } from '../../utils/errors';
+
+export type QuestDBConfig = z.infer<typeof QuestDBConfigSchema>;
+
+/**
+ * QuestDB output plugin.
+ *
+ * Writes data points as InfluxDB line protocol to QuestDB's HTTP ILP endpoint
+ * (`POST /write`). Health is probed via the `/exec` SQL endpoint so we catch
+ * DNS, port, and REST-layer failures rather than just a static page response.
+ *
+ * Default port matches QuestDB's HTTP server (9000). For the faster native
+ * TCP ILP (port 9009) a dedicated transport would be needed; HTTP is a good
+ * default and reuses the existing axios plumbing.
+ */
+export class QuestDBPlugin extends BaseOutputPlugin<QuestDBConfig> {
+  readonly metadata: PluginMetadata = {
+    name: 'QuestDB',
+    version: '1.0.0',
+    description: 'QuestDB output plugin using InfluxDB line protocol over HTTP',
+  };
+
+  private client!: AxiosInstance;
+
+  async initialize(config: QuestDBConfig): Promise<void> {
+    await super.initialize(config);
+
+    const baseURL = this.getBaseUrl();
+
+    this.client = createHttpClient({
+      baseURL,
+      verifySsl: this.config.verifySsl,
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    });
+
+    this.logger.info(`Connected to QuestDB at ${baseURL}`);
+  }
+
+  async write(points: DataPoint[]): Promise<void> {
+    if (points.length === 0) {
+      return;
+    }
+
+    const body = this.toLineProtocolBatch(points);
+
+    try {
+      await withTimeout(
+        this.client.post('/write', body),
+        30000,
+        'QuestDB write timed out after 30000ms'
+      );
+      this.logger.debug(`Wrote ${points.length} points to QuestDB`);
+    } catch (error) {
+      this.logger.error(
+        `Failed to write to QuestDB: ${formatHelpfulError(error, { service: 'QuestDB', url: this.getBaseUrl() })}`
+      );
+      throw error;
+    }
+  }
+
+  async healthCheck(): Promise<boolean> {
+    try {
+      const response = await this.client.get('/exec', {
+        params: { query: 'SELECT 1' },
+      });
+      return response.status === 200;
+    } catch (error) {
+      this.logger.debug(
+        `QuestDB health check failed: ${formatHelpfulError(error, { service: 'QuestDB', url: this.getBaseUrl() })}`
+      );
+      return false;
+    }
+  }
+}

--- a/src/plugins/outputs/index.ts
+++ b/src/plugins/outputs/index.ts
@@ -4,12 +4,14 @@ import type { OutputPluginFactory } from '../../core/PluginManager';
 import { InfluxDB1Plugin } from './InfluxDB1Plugin';
 import { InfluxDB2Plugin } from './InfluxDB2Plugin';
 import { VictoriaMetricsPlugin } from './VictoriaMetricsPlugin';
+import { QuestDBPlugin } from './QuestDBPlugin';
 
 // Re-exports for direct usage
 export { BaseOutputPlugin, BaseOutputConfig } from './BaseOutputPlugin';
 export { InfluxDB1Plugin, InfluxDB1Config } from './InfluxDB1Plugin';
 export { InfluxDB2Plugin, InfluxDB2Config } from './InfluxDB2Plugin';
 export { VictoriaMetricsPlugin, VictoriaMetricsConfig } from './VictoriaMetricsPlugin';
+export { QuestDBPlugin, QuestDBConfig } from './QuestDBPlugin';
 
 /**
  * All available output plugin classes
@@ -19,6 +21,7 @@ const outputPluginClasses: OutputPluginFactory[] = [
   InfluxDB1Plugin,
   InfluxDB2Plugin,
   VictoriaMetricsPlugin,
+  QuestDBPlugin,
 ];
 
 /**

--- a/tests/fixtures/logger.ts
+++ b/tests/fixtures/logger.ts
@@ -9,7 +9,7 @@ import { vi } from 'vitest';
  */
 export const loggerMock = (): {
   createLogger: () => Record<'info' | 'debug' | 'warn' | 'error', ReturnType<typeof vi.fn>>;
-  withContext: (logger: unknown) => unknown;
+  withContext: (logger: unknown, context?: Record<string, unknown>) => unknown;
 } => ({
   createLogger: () => ({
     info: vi.fn(),
@@ -17,5 +17,5 @@ export const loggerMock = (): {
     warn: vi.fn(),
     error: vi.fn(),
   }),
-  withContext: (logger: unknown) => logger,
+  withContext: (logger: unknown, _context?: Record<string, unknown>) => logger,
 });

--- a/tests/plugins/outputs/QuestDBPlugin.test.ts
+++ b/tests/plugins/outputs/QuestDBPlugin.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QuestDBPlugin } from '../../../src/plugins/outputs/QuestDBPlugin';
+import type { DataPoint } from '../../../src/types/plugin.types';
+
+vi.mock('../../../src/core/Logger', async () => {
+  const { loggerMock } = await import('../../fixtures/logger');
+  return loggerMock();
+});
+
+const mockPost = vi.fn().mockResolvedValue({ status: 204 });
+const mockGet = vi.fn().mockResolvedValue({ status: 200 });
+
+vi.mock('../../../src/utils/http', async () => {
+  const actual = await vi.importActual<typeof import('../../../src/utils/http')>(
+    '../../../src/utils/http'
+  );
+  return {
+    ...actual,
+    createHttpClient: vi.fn(() => ({
+      post: mockPost,
+      get: mockGet,
+    })),
+  };
+});
+
+describe('QuestDBPlugin', () => {
+  let plugin: QuestDBPlugin;
+  const testConfig = {
+    url: 'localhost',
+    port: 9000,
+    ssl: false,
+    verifySsl: false,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPost.mockResolvedValue({ status: 204 });
+    mockGet.mockResolvedValue({ status: 200 });
+    plugin = new QuestDBPlugin();
+  });
+
+  describe('metadata', () => {
+    it('exposes correct name, version, and description', () => {
+      expect(plugin.metadata.name).toBe('QuestDB');
+      expect(plugin.metadata.version).toBe('1.0.0');
+      expect(plugin.metadata.description).toContain('QuestDB');
+    });
+  });
+
+  describe('initialize', () => {
+    it('initializes cleanly with plain config', async () => {
+      await expect(plugin.initialize(testConfig)).resolves.toBeUndefined();
+    });
+
+    it('initializes with SSL enabled', async () => {
+      await expect(
+        plugin.initialize({ ...testConfig, ssl: true, verifySsl: true })
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('write', () => {
+    beforeEach(async () => {
+      await plugin.initialize(testConfig);
+    });
+
+    it('POSTs an ILP body to /write for a single point', async () => {
+      const points: DataPoint[] = [
+        {
+          measurement: 'sonarr',
+          tags: { host: 'server1' },
+          fields: { queue_size: 5 },
+          timestamp: new Date('2026-04-24T00:00:00Z'),
+        },
+      ];
+
+      await plugin.write(points);
+
+      expect(mockPost).toHaveBeenCalledTimes(1);
+      const [path, body] = mockPost.mock.calls[0];
+      expect(path).toBe('/write');
+      expect(body).toContain('sonarr');
+      expect(body).toContain('host=server1');
+      expect(body).toContain('queue_size=5i');
+    });
+
+    it('batches multiple points in a single request', async () => {
+      const points: DataPoint[] = [
+        { measurement: 'a', tags: {}, fields: { v: 1 }, timestamp: new Date() },
+        { measurement: 'b', tags: {}, fields: { v: 2 }, timestamp: new Date() },
+      ];
+
+      await plugin.write(points);
+
+      expect(mockPost).toHaveBeenCalledTimes(1);
+      const [, body] = mockPost.mock.calls[0];
+      expect((body as string).split('\n')).toHaveLength(2);
+    });
+
+    it('skips the write when no points are provided', async () => {
+      await plugin.write([]);
+      expect(mockPost).not.toHaveBeenCalled();
+    });
+
+    it('propagates write errors for the circuit breaker', async () => {
+      mockPost.mockRejectedValueOnce(new Error('connection refused'));
+      const points: DataPoint[] = [
+        { measurement: 'm', tags: {}, fields: { v: 1 }, timestamp: new Date() },
+      ];
+
+      await expect(plugin.write(points)).rejects.toThrow('connection refused');
+    });
+  });
+
+  describe('healthCheck', () => {
+    beforeEach(async () => {
+      await plugin.initialize(testConfig);
+    });
+
+    it('returns true when /exec?query=SELECT 1 responds 200', async () => {
+      mockGet.mockResolvedValueOnce({ status: 200 });
+      await expect(plugin.healthCheck()).resolves.toBe(true);
+      expect(mockGet).toHaveBeenCalledWith('/exec', { params: { query: 'SELECT 1' } });
+    });
+
+    it('returns false on non-200 response', async () => {
+      mockGet.mockResolvedValueOnce({ status: 503 });
+      await expect(plugin.healthCheck()).resolves.toBe(false);
+    });
+
+    it('returns false when the request throws', async () => {
+      mockGet.mockRejectedValueOnce(new Error('network error'));
+      await expect(plugin.healthCheck()).resolves.toBe(false);
+    });
+  });
+
+  describe('shutdown', () => {
+    it('shuts down cleanly', async () => {
+      await plugin.initialize(testConfig);
+      await expect(plugin.shutdown()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/tests/plugins/outputs/index.test.ts
+++ b/tests/plugins/outputs/index.test.ts
@@ -5,6 +5,7 @@ import {
   InfluxDB1Plugin,
   InfluxDB2Plugin,
   VictoriaMetricsPlugin,
+  QuestDBPlugin,
 } from '../../../src/plugins/outputs';
 
 describe('Output Plugins Index', () => {
@@ -19,11 +20,12 @@ describe('Output Plugins Index', () => {
       expect(registry.has('influxdb1')).toBe(true);
       expect(registry.has('influxdb2')).toBe(true);
       expect(registry.has('victoriametrics')).toBe(true);
+      expect(registry.has('questdb')).toBe(true);
     });
 
     it('should have correct number of plugins', () => {
       const registry = getOutputPluginRegistry();
-      expect(registry.size).toBe(3);
+      expect(registry.size).toBe(4);
     });
 
     it('should return plugin classes that can be instantiated', () => {
@@ -48,6 +50,9 @@ describe('Output Plugins Index', () => {
 
       const vmPlugin = new VictoriaMetricsPlugin();
       expect(registry.has(vmPlugin.metadata.name.toLowerCase())).toBe(true);
+
+      const questdbPlugin = new QuestDBPlugin();
+      expect(registry.has(questdbPlugin.metadata.name.toLowerCase())).toBe(true);
     });
   });
 
@@ -66,6 +71,10 @@ describe('Output Plugins Index', () => {
 
     it('should export VictoriaMetricsPlugin', () => {
       expect(VictoriaMetricsPlugin).toBeDefined();
+    });
+
+    it('should export QuestDBPlugin', () => {
+      expect(QuestDBPlugin).toBeDefined();
     });
   });
 });


### PR DESCRIPTION
## Description

Adds a new `QuestDBPlugin` that writes data points to QuestDB using the InfluxDB line protocol over HTTP.

### Implementation

- **Endpoint:** `POST /write` with ILP body (reuses `toLineProtocolBatch()` from `BaseOutputPlugin`)
- **Default port:** 9000 (QuestDB HTTP server)
- **Health check:** `GET /exec?query=SELECT 1` — exercises the full REST/SQL layer, not just the static web page served on `/`
- **Transport:** HTTP via `axios` (already installed). Native TCP ILP on port 9009 would be faster for very high ingestion rates; leaving it as a future enhancement if the need arises.

The config schema was already defined (`QuestDBConfigSchema`); this scope just ships the plugin.

### Testing

- 11 new unit tests for `QuestDBPlugin` (metadata, init with/without SSL, single + batch writes, empty batch skip, write error propagation, health success/non-200/throw, shutdown)
- Registry test updated (`outputs/index.test.ts`): now expects 4 plugins
- Uses the new `tests/fixtures/logger.ts` fixture

### Coverage

- `QuestDBPlugin.ts`: **100%**
- Global: 91.15% → **91.23%**

## Type of change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [ ] Dependencies update

## Checklist
- [x] I have tested my changes locally
- [x] I have added/updated tests if needed (+12)
- [x] Code coverage is maintained or improved
- [x] Lint passes (`npm run lint`)
- [x] Tests pass (`npm test`) — 660 passed

## Related

Part of Phase 8 (Additional Output Plugins) in PLAN.md. Only TimescaleDB remains in that phase.