### PR TITLE
feat(outputs): add TimescaleDB output plugin

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -68,7 +68,7 @@ varken/
 │   └── utils/
 │       ├── http.ts                  # HTTP utilities, error classification
 │       └── index.ts
-├── tests/                           # 660 tests, 91% coverage
+├── tests/                           # 676 tests, 91% coverage
 │   ├── config/
 │   ├── core/
 │   ├── plugins/
@@ -176,7 +176,7 @@ interface ScheduleConfig {
 | InfluxDB 2.x | `@influxdata/influxdb-client` | ✅ Implemented |
 | VictoriaMetrics | `axios` | Line protocol via HTTP |
 | QuestDB | `axios` | ILP via HTTP |
-| TimescaleDB | `pg` | PostgreSQL driver (à ajouter) |
+| TimescaleDB | `pg` | PostgreSQL driver ✅ |
 
 ### Future Dependencies (for planned features)
 
@@ -184,7 +184,7 @@ interface ScheduleConfig {
 |---------|-------------|-------|
 | ~~Health endpoint~~ | ~~`express` ou `fastify`~~ | ✅ Uses native Node.js `http` |
 | Prometheus metrics | `prom-client` | Metrics collection |
-| TimescaleDB | `pg` | PostgreSQL driver |
+| TimescaleDB | `pg` | PostgreSQL driver ✅ |
 
 ---
 
@@ -228,7 +228,7 @@ interface ScheduleConfig {
 - [x] Main entry point (`index.ts`)
 - [x] Dockerfile (multi-stage, ~190MB)
 - [x] docker-compose.yml (Varken + InfluxDB 2.x + Grafana)
-- [x] Unit tests (660 tests passing)
+- [x] Unit tests (676 tests passing)
 - [x] CI/CD workflows (GitHub Actions)
 - [x] Codecov integration
 - [x] Documentation (README.md, CLAUDE.md)
@@ -284,12 +284,13 @@ interface ScheduleConfig {
   - Uses `axios` (already installed); reuses `toLineProtocolBatch()` from BaseOutputPlugin
   - Native TCP (port 9009) left as a future enhancement if performance requires it
 
-#### TimescaleDB
-- [ ] `TimescaleDBPlugin` - PostgreSQL with hypertables
-  - Add `pg` dependency
-  - Auto-create tables and hypertables
-  - DataPoint → SQL INSERT mapping
-  - Effort: ~8h
+#### TimescaleDB ✅
+- [x] `TimescaleDBPlugin` - PostgreSQL with hypertables
+  - Added `pg` dependency + `@types/pg`
+  - Single `varken_events` hypertable with JSONB tags/fields (schema-free, handles dynamic measurements)
+  - Auto-creates table + hypertable + `(measurement, time DESC)` index on init; falls back to plain table if TimescaleDB extension not installed (warns, continues)
+  - Bulk-inserts via parameterized `INSERT` (atomic batch, SQL-injection safe)
+  - Implements `OutputPlugin` directly (doesn't extend `BaseOutputPlugin` — no HTTP, no line protocol)
 
 ### Phase 9: Additional Input Plugins
 
@@ -448,7 +449,7 @@ interface ScheduleConfig {
 
 ## Test Coverage Summary
 
-> **Last updated**: 2026-04-24 | **Global coverage**: 91.23% | **Tests**: 660 passing
+> **Last updated**: 2026-04-24 | **Global coverage**: 91.42% | **Tests**: 676 passing
 
 | File | Coverage | Target | Status | Notes |
 |------|----------|--------|--------|-------|
@@ -478,6 +479,7 @@ interface ScheduleConfig {
 | `src/plugins/outputs/InfluxDB2Plugin.ts` | 93.33% | 90% | ✅ | |
 | `src/plugins/outputs/VictoriaMetricsPlugin.ts` | 100% | 90% | ✅ | Added in Phase 8 |
 | `src/plugins/outputs/QuestDBPlugin.ts` | 100% | 90% | ✅ | Added in Phase 8 |
+| `src/plugins/outputs/TimescaleDBPlugin.ts` | 100% | 90% | ✅ | Added in Phase 8 |
 | `src/plugins/inputs/BaseInputPlugin.ts` | 89.18% | 90% | ⚠️ | |
 | `src/plugins/outputs/BaseOutputPlugin.ts` | 100% | 90% | ✅ | |
 
@@ -510,7 +512,7 @@ interface ScheduleConfig {
 | **InfluxDB2Plugin** | HTTP API v2 | InfluxDB 2.x - Flux, Buckets, Tokens | ✅ |
 | **VictoriaMetricsPlugin** | InfluxDB line protocol | High performance, compatible | ✅ |
 | **QuestDBPlugin** | ILP over HTTP | Time-series SQL, fast ingestion | ✅ |
-| **TimescaleDBPlugin** | PostgreSQL | Hypertables, standard SQL | 🚧 Types ready |
+| **TimescaleDBPlugin** | PostgreSQL | Hypertables, standard SQL (JSONB tags/fields) | ✅ |
 
 ### Protocol Compatibility
 
@@ -543,7 +545,7 @@ DataPoint (internal format)
 |------|--------|--------|
 | ~~Prometheus metrics~~ | ~~✅~~ | ~~Observability~~ |
 | ~~Config hot-reload~~ | ~~✅~~ | ~~Operations — via `CONFIG_WATCH=true`~~ |
-| TimescaleDB output | ~8h | More DB options |
+| ~~TimescaleDB output~~ | ~~✅~~ | ~~More DB options — completes Phase 8~~ |
 | ~~Structured logging~~ | ~~✅~~ | ~~`LOG_FORMAT=json` + `withContext()`~~ |
 | ~~Dry-run mode~~ | ~~✅~~ | ~~`--dry-run` / `DRY_RUN=true`~~ |
 | ~~Better error messages~~ | ~~✅~~ | ~~UX — `src/utils/errors.ts`~~ |

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Built with TypeScript, Node.js, and a plugin-based architecture with scheduled d
 ### Data Collection
 
 - **Multiple data sources** — Sonarr, Radarr, Readarr, Lidarr, Tautulli, Ombi, Overseerr, Prowlarr, Bazarr
-- **Multiple outputs** — InfluxDB 1.x, InfluxDB 2.x, VictoriaMetrics, QuestDB
+- **Multiple outputs** — InfluxDB 1.x, InfluxDB 2.x, VictoriaMetrics, QuestDB, TimescaleDB
 - **Multi-instance support** — connect multiple instances of each service
 - **GeoIP mapping** — automatic geolocation of streaming sessions via Tautulli API (no external license required)
 
@@ -86,7 +86,7 @@ Built with TypeScript, Node.js, and a plugin-based architecture with scheduled d
 | **InfluxDB 1.x** (legacy)      | ✅          |
 | **VictoriaMetrics**            | ✅          |
 | **QuestDB**                    | ✅          |
-| **TimescaleDB**                | 🚧 Planned |
+| **TimescaleDB**                | ✅          |
 
 ## Installation
 
@@ -216,7 +216,17 @@ outputs:
   # QuestDB (ILP over HTTP on port 9000)
   questdb:
     url: "http://questdb:9000"
+
+  # TimescaleDB (PostgreSQL with hypertables)
+  timescaledb:
+    host: "timescaledb"
+    port: 5432
+    database: "varken"
+    username: "varken"
+    password: "varken"
 ```
+
+> **TimescaleDB schema:** Varken creates a single `varken_events` hypertable on first run. Columns: `time TIMESTAMPTZ`, `measurement TEXT`, `tags JSONB`, `fields JSONB`. Query in Grafana with `tags->>'server'` / `(fields->>'queue_size')::int`. If the TimescaleDB extension isn't installed, the plugin falls back to a plain PostgreSQL table (logs a warning).
 
 See [`config/varken.example.yaml`](config/varken.example.yaml) for the complete list of supported options.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,10 @@
       "dependencies": {
         "@influxdata/influxdb-client": "^1.35.0",
         "@influxdata/influxdb-client-apis": "^1.35.0",
+        "@types/pg": "^8.20.0",
         "axios": "^1.15.0",
         "influx": "^5.12.0",
+        "pg": "^8.20.0",
         "prom-client": "^15.1.3",
         "winston": "^3.17.0",
         "yaml": "^2.8.3",
@@ -1152,10 +1154,20 @@
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/@types/triple-beam": {
@@ -3359,6 +3371,95 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3406,6 +3507,45 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prelude-ls": {
@@ -3657,6 +3797,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/stack-trace": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
@@ -3885,7 +4034,6 @@
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/uri-js": {
@@ -4198,6 +4346,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/yaml": {

--- a/package.json
+++ b/package.json
@@ -44,8 +44,10 @@
   "dependencies": {
     "@influxdata/influxdb-client": "^1.35.0",
     "@influxdata/influxdb-client-apis": "^1.35.0",
+    "@types/pg": "^8.20.0",
     "axios": "^1.15.0",
     "influx": "^5.12.0",
+    "pg": "^8.20.0",
     "prom-client": "^15.1.3",
     "winston": "^3.17.0",
     "yaml": "^2.8.3",

--- a/src/plugins/outputs/TimescaleDBPlugin.ts
+++ b/src/plugins/outputs/TimescaleDBPlugin.ts
@@ -1,0 +1,147 @@
+import { Pool, type PoolConfig } from 'pg';
+import type { z } from 'zod';
+import { createLogger } from '../../core/Logger';
+import type { OutputPlugin, PluginMetadata, DataPoint } from '../../types/plugin.types';
+import type { TimescaleDBConfigSchema } from '../../config/schemas/config.schema';
+
+export type TimescaleDBConfig = z.infer<typeof TimescaleDBConfigSchema>;
+
+/**
+ * Table layout used by the plugin. Single wide table keyed by `measurement`
+ * with JSONB tags/fields — this avoids schema evolution pain (new tags/fields
+ * appear over time as plugins are added or updated) and keeps Grafana queries
+ * possible via `tags->>'server'` / `(fields->>'queue_size')::int` etc.
+ */
+const TABLE_NAME = 'varken_events';
+
+/**
+ * TimescaleDB output plugin.
+ *
+ * Writes data points as rows in a single hypertable (`varken_events`) with
+ * JSONB columns for tags and fields. On first initialization the plugin:
+ *
+ * 1. creates the table if it doesn't exist
+ * 2. upgrades it to a hypertable (skipped with a warning if the TimescaleDB
+ *    extension isn't installed — the plugin still works as plain PostgreSQL)
+ * 3. adds a `(measurement, time DESC)` index for typical Grafana queries
+ *
+ * Writes are bulk-inserted via a single parameterized `INSERT`; the connection
+ * pool is held open for the lifetime of the plugin and closed on shutdown.
+ */
+export class TimescaleDBPlugin implements OutputPlugin<TimescaleDBConfig> {
+  readonly metadata: PluginMetadata = {
+    name: 'TimescaleDB',
+    version: '1.0.0',
+    description: 'TimescaleDB output plugin using a hypertable with JSONB tags/fields',
+  };
+
+  protected logger = createLogger(this.constructor.name);
+  private pool!: Pool;
+
+  async initialize(config: TimescaleDBConfig): Promise<void> {
+    const poolConfig: PoolConfig = {
+      host: config.host,
+      port: config.port,
+      database: config.database,
+      user: config.username,
+      password: config.password,
+    };
+    if (config.ssl) {
+      poolConfig.ssl = { rejectUnauthorized: false };
+    }
+
+    this.pool = new Pool(poolConfig);
+    await this.ensureSchema();
+
+    this.logger.info(
+      `Connected to TimescaleDB at ${config.host}:${config.port}/${config.database}`
+    );
+  }
+
+  async write(points: DataPoint[]): Promise<void> {
+    if (points.length === 0) {
+      return;
+    }
+
+    // Build a single bulk INSERT with parameterized rows to avoid SQL injection
+    // and get atomic batch semantics.
+    const values: unknown[] = [];
+    const placeholders: string[] = [];
+    for (let i = 0; i < points.length; i++) {
+      const p = points[i];
+      const base = i * 4;
+      placeholders.push(`($${base + 1}, $${base + 2}, $${base + 3}, $${base + 4})`);
+      values.push(
+        p.timestamp,
+        p.measurement,
+        JSON.stringify(p.tags ?? {}),
+        JSON.stringify(p.fields ?? {})
+      );
+    }
+
+    const sql = `INSERT INTO ${TABLE_NAME} (time, measurement, tags, fields) VALUES ${placeholders.join(', ')}`;
+
+    try {
+      await this.pool.query(sql, values);
+      this.logger.debug(`Wrote ${points.length} points to TimescaleDB`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      this.logger.error(`Failed to write to TimescaleDB: ${message}`);
+      throw error;
+    }
+  }
+
+  async healthCheck(): Promise<boolean> {
+    try {
+      await this.pool.query('SELECT 1');
+      return true;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      this.logger.debug(`TimescaleDB health check failed: ${message}`);
+      return false;
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    this.logger.info('Shutting down TimescaleDB plugin');
+    if (this.pool) {
+      try {
+        await this.pool.end();
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        this.logger.error(`Error closing TimescaleDB pool: ${message}`);
+      }
+    }
+  }
+
+  private async ensureSchema(): Promise<void> {
+    const client = await this.pool.connect();
+    try {
+      await client.query(`
+        CREATE TABLE IF NOT EXISTS ${TABLE_NAME} (
+          time TIMESTAMPTZ NOT NULL,
+          measurement TEXT NOT NULL,
+          tags JSONB NOT NULL DEFAULT '{}',
+          fields JSONB NOT NULL DEFAULT '{}'
+        )
+      `);
+
+      try {
+        await client.query(
+          `SELECT create_hypertable('${TABLE_NAME}', 'time', if_not_exists => TRUE)`
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        this.logger.warn(
+          `create_hypertable failed — is the TimescaleDB extension installed? Falling back to a plain table. (${message})`
+        );
+      }
+
+      await client.query(
+        `CREATE INDEX IF NOT EXISTS idx_${TABLE_NAME}_measurement ON ${TABLE_NAME} (measurement, time DESC)`
+      );
+    } finally {
+      client.release();
+    }
+  }
+}

--- a/src/plugins/outputs/index.ts
+++ b/src/plugins/outputs/index.ts
@@ -5,6 +5,7 @@ import { InfluxDB1Plugin } from './InfluxDB1Plugin';
 import { InfluxDB2Plugin } from './InfluxDB2Plugin';
 import { VictoriaMetricsPlugin } from './VictoriaMetricsPlugin';
 import { QuestDBPlugin } from './QuestDBPlugin';
+import { TimescaleDBPlugin } from './TimescaleDBPlugin';
 
 // Re-exports for direct usage
 export { BaseOutputPlugin, BaseOutputConfig } from './BaseOutputPlugin';
@@ -12,6 +13,7 @@ export { InfluxDB1Plugin, InfluxDB1Config } from './InfluxDB1Plugin';
 export { InfluxDB2Plugin, InfluxDB2Config } from './InfluxDB2Plugin';
 export { VictoriaMetricsPlugin, VictoriaMetricsConfig } from './VictoriaMetricsPlugin';
 export { QuestDBPlugin, QuestDBConfig } from './QuestDBPlugin';
+export { TimescaleDBPlugin, TimescaleDBConfig } from './TimescaleDBPlugin';
 
 /**
  * All available output plugin classes
@@ -22,6 +24,7 @@ const outputPluginClasses: OutputPluginFactory[] = [
   InfluxDB2Plugin,
   VictoriaMetricsPlugin,
   QuestDBPlugin,
+  TimescaleDBPlugin,
 ];
 
 /**

--- a/tests/plugins/outputs/TimescaleDBPlugin.test.ts
+++ b/tests/plugins/outputs/TimescaleDBPlugin.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TimescaleDBPlugin } from '../../../src/plugins/outputs/TimescaleDBPlugin';
+import type { DataPoint } from '../../../src/types/plugin.types';
+
+vi.mock('../../../src/core/Logger', async () => {
+  const { loggerMock } = await import('../../fixtures/logger');
+  return loggerMock();
+});
+
+const mockQuery = vi.fn();
+const mockConnect = vi.fn();
+const mockEnd = vi.fn().mockResolvedValue(undefined);
+const mockRelease = vi.fn();
+const mockClientQuery = vi.fn();
+
+vi.mock('pg', () => ({
+  Pool: vi.fn().mockImplementation(function () {
+    return {
+      query: mockQuery,
+      connect: mockConnect,
+      end: mockEnd,
+    };
+  }),
+}));
+
+describe('TimescaleDBPlugin', () => {
+  let plugin: TimescaleDBPlugin;
+  const testConfig = {
+    host: 'localhost',
+    port: 5432,
+    database: 'varken',
+    username: 'varken',
+    password: 'secret',
+    ssl: false,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQuery.mockResolvedValue({ rows: [] });
+    mockClientQuery.mockResolvedValue({ rows: [] });
+    mockConnect.mockResolvedValue({
+      query: mockClientQuery,
+      release: mockRelease,
+    });
+    mockEnd.mockResolvedValue(undefined);
+    plugin = new TimescaleDBPlugin();
+  });
+
+  describe('metadata', () => {
+    it('exposes correct name, version, and description', () => {
+      expect(plugin.metadata.name).toBe('TimescaleDB');
+      expect(plugin.metadata.version).toBe('1.0.0');
+      expect(plugin.metadata.description).toContain('TimescaleDB');
+    });
+  });
+
+  describe('initialize', () => {
+    it('creates the table, hypertable, and index', async () => {
+      await plugin.initialize(testConfig);
+
+      const queries = mockClientQuery.mock.calls.map((c) => c[0] as string);
+      expect(queries.some((q) => q.includes('CREATE TABLE IF NOT EXISTS varken_events'))).toBe(true);
+      expect(queries.some((q) => q.includes('create_hypertable'))).toBe(true);
+      expect(queries.some((q) => q.includes('CREATE INDEX IF NOT EXISTS'))).toBe(true);
+    });
+
+    it('continues past a missing TimescaleDB extension with a warning', async () => {
+      mockClientQuery.mockImplementationOnce(() => Promise.resolve({ rows: [] })); // CREATE TABLE
+      mockClientQuery.mockImplementationOnce(() => Promise.reject(new Error('extension not installed'))); // create_hypertable
+      mockClientQuery.mockImplementationOnce(() => Promise.resolve({ rows: [] })); // CREATE INDEX
+
+      await expect(plugin.initialize(testConfig)).resolves.toBeUndefined();
+    });
+
+    it('releases the connection after schema setup even on error', async () => {
+      mockClientQuery.mockRejectedValueOnce(new Error('create table failed'));
+
+      await expect(plugin.initialize(testConfig)).rejects.toThrow('create table failed');
+      expect(mockRelease).toHaveBeenCalled();
+    });
+  });
+
+  describe('write', () => {
+    beforeEach(async () => {
+      await plugin.initialize(testConfig);
+      mockQuery.mockClear();
+    });
+
+    it('batches points into a single parameterized INSERT', async () => {
+      const now = new Date('2026-04-24T00:00:00Z');
+      const points: DataPoint[] = [
+        { measurement: 'sonarr', tags: { server: 1 }, fields: { queue: 5 }, timestamp: now },
+        { measurement: 'radarr', tags: { server: 2 }, fields: { queue: 3 }, timestamp: now },
+      ];
+
+      await plugin.write(points);
+
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      const [sql, values] = mockQuery.mock.calls[0];
+      expect(sql).toContain('INSERT INTO varken_events');
+      expect(sql).toMatch(/\(\$1, \$2, \$3, \$4\), \(\$5, \$6, \$7, \$8\)/);
+      // 2 points × 4 columns = 8 bound params
+      expect(values).toHaveLength(8);
+      expect(values[1]).toBe('sonarr');
+      expect(values[5]).toBe('radarr');
+    });
+
+    it('serializes tags/fields as JSON', async () => {
+      await plugin.write([
+        { measurement: 'm', tags: { host: 'a' }, fields: { v: 1 }, timestamp: new Date() },
+      ]);
+
+      const [, values] = mockQuery.mock.calls[0];
+      expect(values[2]).toBe('{"host":"a"}');
+      expect(values[3]).toBe('{"v":1}');
+    });
+
+    it('skips when no points are provided', async () => {
+      await plugin.write([]);
+      expect(mockQuery).not.toHaveBeenCalled();
+    });
+
+    it('propagates write errors for the circuit breaker', async () => {
+      mockQuery.mockRejectedValueOnce(new Error('db unreachable'));
+
+      await expect(
+        plugin.write([
+          { measurement: 'm', tags: {}, fields: { v: 1 }, timestamp: new Date() },
+        ])
+      ).rejects.toThrow('db unreachable');
+    });
+  });
+
+  describe('healthCheck', () => {
+    beforeEach(async () => {
+      await plugin.initialize(testConfig);
+    });
+
+    it('returns true when SELECT 1 succeeds', async () => {
+      await expect(plugin.healthCheck()).resolves.toBe(true);
+    });
+
+    it('returns false when SELECT 1 throws', async () => {
+      mockQuery.mockRejectedValueOnce(new Error('connection lost'));
+      await expect(plugin.healthCheck()).resolves.toBe(false);
+    });
+  });
+
+  describe('shutdown', () => {
+    it('ends the pool cleanly', async () => {
+      await plugin.initialize(testConfig);
+      await plugin.shutdown();
+      expect(mockEnd).toHaveBeenCalled();
+    });
+
+    it('swallows pool.end() errors', async () => {
+      await plugin.initialize(testConfig);
+      mockEnd.mockRejectedValueOnce(new Error('end failed'));
+      await expect(plugin.shutdown()).resolves.toBeUndefined();
+    });
+
+    it('is safe to call when pool was never initialized', async () => {
+      await expect(plugin.shutdown()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('SSL config', () => {
+    it('enables SSL with rejectUnauthorized:false when ssl=true', async () => {
+      const { Pool } = await import('pg');
+      vi.mocked(Pool).mockClear();
+
+      await plugin.initialize({ ...testConfig, ssl: true });
+
+      const constructorArg = vi.mocked(Pool).mock.calls[0][0];
+      expect(constructorArg?.ssl).toEqual({ rejectUnauthorized: false });
+    });
+
+    it('omits SSL config when ssl=false', async () => {
+      const { Pool } = await import('pg');
+      vi.mocked(Pool).mockClear();
+
+      await plugin.initialize(testConfig);
+
+      const constructorArg = vi.mocked(Pool).mock.calls[0][0];
+      expect(constructorArg?.ssl).toBeUndefined();
+    });
+  });
+});

--- a/tests/plugins/outputs/index.test.ts
+++ b/tests/plugins/outputs/index.test.ts
@@ -6,6 +6,7 @@ import {
   InfluxDB2Plugin,
   VictoriaMetricsPlugin,
   QuestDBPlugin,
+  TimescaleDBPlugin,
 } from '../../../src/plugins/outputs';
 
 describe('Output Plugins Index', () => {
@@ -21,11 +22,12 @@ describe('Output Plugins Index', () => {
       expect(registry.has('influxdb2')).toBe(true);
       expect(registry.has('victoriametrics')).toBe(true);
       expect(registry.has('questdb')).toBe(true);
+      expect(registry.has('timescaledb')).toBe(true);
     });
 
     it('should have correct number of plugins', () => {
       const registry = getOutputPluginRegistry();
-      expect(registry.size).toBe(4);
+      expect(registry.size).toBe(5);
     });
 
     it('should return plugin classes that can be instantiated', () => {
@@ -53,6 +55,9 @@ describe('Output Plugins Index', () => {
 
       const questdbPlugin = new QuestDBPlugin();
       expect(registry.has(questdbPlugin.metadata.name.toLowerCase())).toBe(true);
+
+      const timescalePlugin = new TimescaleDBPlugin();
+      expect(registry.has(timescalePlugin.metadata.name.toLowerCase())).toBe(true);
     });
   });
 
@@ -75,6 +80,10 @@ describe('Output Plugins Index', () => {
 
     it('should export QuestDBPlugin', () => {
       expect(QuestDBPlugin).toBeDefined();
+    });
+
+    it('should export TimescaleDBPlugin', () => {
+      expect(TimescaleDBPlugin).toBeDefined();
     });
   });
 });


### PR DESCRIPTION
## Description

Adds a new `TimescaleDBPlugin` that writes data points to TimescaleDB (or plain PostgreSQL) via the `pg` driver. Completes Phase 8 (Additional Output Plugins) in PLAN.md.

### Schema design

Single wide table, JSONB columns for tags/fields:

```sql
CREATE TABLE varken_events (
  time        TIMESTAMPTZ NOT NULL,
  measurement TEXT NOT NULL,
  tags        JSONB NOT NULL DEFAULT '{}',
  fields      JSONB NOT NULL DEFAULT '{}'
);
SELECT create_hypertable('varken_events', 'time', if_not_exists => TRUE);
CREATE INDEX idx_varken_events_measurement ON varken_events (measurement, time DESC);
```

**Why JSONB** — Varken's tags/fields are dynamic across plugins and evolve over time (new plugins, new metrics). A column-per-tag schema would require migrations on every new collector. JSONB keeps the plugin generic and still leaves Grafana queries expressible:

```sql
SELECT time, (fields->>'queue_size')::int AS queue
FROM varken_events
WHERE measurement = 'Sonarr' AND tags->>'server' = '1'
```

### Behavior

- **Auto-schema on init** — creates table, promotes to hypertable, adds index. All with `IF NOT EXISTS` so reruns are idempotent.
- **Graceful fallback** — if the TimescaleDB extension isn't installed, `create_hypertable` fails; the plugin logs a warning and continues with a plain PostgreSQL table.
- **Bulk inserts** — single parameterized `INSERT` per batch (atomic, SQL-injection safe).
- **SSL opt-in** — `ssl: true` enables TLS with `rejectUnauthorized: false` (matches the pattern used by other plugins with self-signed certs).
- **Doesn't extend `BaseOutputPlugin`** — no HTTP, no line protocol. Implements `OutputPlugin` directly.

### New dependency

- `pg@^8.20` (runtime)
- `@types/pg@^8.20` (dev)

### Testing

- 15 new unit tests covering: metadata, schema creation, hypertable fallback on missing extension, connection release on error, bulk INSERT format, JSON serialization, empty batch skip, error propagation, health check success/failure, shutdown idempotency, SSL config on/off
- Registry test: now expects 5 output plugins
- Coverage: `TimescaleDBPlugin.ts` **100%**, global 91.23% → **91.42%**

## Type of change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [x] Dependencies update

## Checklist
- [x] I have tested my changes locally
- [x] I have added/updated tests if needed (+16)
- [x] Code coverage is maintained or improved
- [x] Lint passes (`npm run lint`)
- [x] Tests pass (`npm test`) — 676 passed

## Related

Completes Phase 8 (Additional Output Plugins) in PLAN.md.