### PR TITLE
feat(inputs): add JellyfinPlugin

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -68,7 +68,7 @@ varken/
 │   └── utils/
 │       ├── http.ts                  # HTTP utilities, error classification
 │       └── index.ts
-├── tests/                           # 688 tests, 91% coverage
+├── tests/                           # 700 tests, 91% coverage
 │   ├── config/
 │   ├── core/
 │   ├── plugins/
@@ -228,7 +228,7 @@ interface ScheduleConfig {
 - [x] Main entry point (`index.ts`)
 - [x] Dockerfile (multi-stage, ~190MB)
 - [x] docker-compose.yml (Varken + InfluxDB 2.x + Grafana)
-- [x] Unit tests (688 tests passing)
+- [x] Unit tests (700 tests passing)
 - [x] CI/CD workflows (GitHub Actions)
 - [x] Codecov integration
 - [x] Documentation (README.md, CLAUDE.md)
@@ -305,9 +305,11 @@ interface ScheduleConfig {
   - Alternative to Tautulli — direct `GET /status/sessions` + `GET /library/sections`
   - `X-Plex-Token` header auth, `Accept: application/json` header override (Plex defaults to XML)
   - Library item counts via `/library/sections/{key}/all?X-Plex-Container-Size=0` (cheap, no item transfer)
-- [ ] `JellyfinPlugin` - sessions, libraries, activity
-  - Types already defined in `src/types/inputs/jellyfin.types.ts`
-  - Effort: ~8h
+- [x] `JellyfinPlugin` - sessions, libraries ✅
+  - Direct Jellyfin API (`/Sessions`, `/Library/VirtualFolders`, `/Items/Counts`)
+  - `X-Emby-Token` header auth (compatible with Emby forks)
+  - Emits per-session DataPoints + `current_stream_stats` summary + per-library + global `item_counts`
+  - Non-fatal fallback when `/Items/Counts` fails
 - [ ] `EmbyPlugin` - sessions, libraries, activity
   - Similar to Jellyfin, API /emby/api
   - Types already defined in `src/types/inputs/emby.types.ts`
@@ -449,7 +451,7 @@ interface ScheduleConfig {
 
 ## Test Coverage Summary
 
-> **Last updated**: 2026-04-24 | **Global coverage**: 91.38% | **Tests**: 688 passing
+> **Last updated**: 2026-04-24 | **Global coverage**: 91.54% | **Tests**: 700 passing
 
 | File | Coverage | Target | Status | Notes |
 |------|----------|--------|--------|-------|
@@ -472,6 +474,7 @@ interface ScheduleConfig {
 | `src/plugins/inputs/OmbiPlugin.ts` | 93.67% | 90% | ✅ | Improved via safeFetch refactor |
 | `src/plugins/inputs/OverseerrPlugin.ts` | 91.17% | 90% | ✅ | Improved via safeFetch refactor |
 | `src/plugins/inputs/PlexPlugin.ts` | 90% | 90% | ✅ | Added in Phase 9 (direct Plex API) |
+| `src/plugins/inputs/JellyfinPlugin.ts` | 98.15% | 90% | ✅ | Added in Phase 9 |
 | `src/plugins/inputs/ReadarrPlugin.ts` | 98.03% | 90% | ✅ | Improved via safeFetch refactor |
 | `src/plugins/inputs/LidarrPlugin.ts` | 100% | 90% | ✅ | |
 | `src/plugins/inputs/BazarrPlugin.ts` | 100% | 90% | ✅ | |
@@ -498,7 +501,7 @@ interface ScheduleConfig {
 | **Bazarr** | /api | Wanted subtitles, History | ✅ |
 | **Tautulli** | /api/v2 | Activity, Libraries, Stats + GeoIP | ✅ |
 | **Plex** | /api | Sessions, Libraries (direct API) | ✅ |
-| **Jellyfin** | /api | Sessions, Libraries, Activity | 🚧 Types ready |
+| **Jellyfin** | /api | Sessions, Libraries, Item counts | ✅ |
 | **Emby** | /emby/api | Sessions, Libraries, Activity | 🚧 Types ready |
 | **Ombi** | /api/v1 | Request counts, Issue counts | ✅ |
 | **Overseerr** | /api/v1 | Request counts, Latest requests | ✅ |
@@ -555,7 +558,7 @@ DataPoint (internal format)
 ### Low Priority
 | Item | Effort | Impact |
 |------|--------|--------|
-| Jellyfin, Emby inputs | ~16h | Alternative to Tautulli (Plex done ✅) |
+| Emby input | ~8h | Alternative to Tautulli (Plex + Jellyfin done ✅) |
 | CLI tool | ~8h | Admin UX |
 | ~~Pre-commit hooks~~ | ~~✅~~ | ~~DX - husky + lint-staged~~ |
 | ~~CHANGELOG auto-generation~~ | ~~✅~~ | ~~GitHub Actions on tag~~ |

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Built with TypeScript, Node.js, and a plugin-based architecture with scheduled d
 | **Prowlarr**  | Indexer statistics                        | ✅          |
 | **Bazarr**    | Wanted subtitles, history                 | ✅          |
 | **Plex**      | Sessions, libraries (direct API)          | ✅          |
-| **Jellyfin**  | Sessions, libraries, activity             | 🚧 Planned |
+| **Jellyfin**  | Sessions, libraries, item counts          | ✅          |
 
 ### Output Plugins
 

--- a/src/plugins/inputs/JellyfinPlugin.ts
+++ b/src/plugins/inputs/JellyfinPlugin.ts
@@ -1,0 +1,215 @@
+import { BaseInputPlugin } from './BaseInputPlugin';
+import type { PluginMetadata, DataPoint, ScheduleConfig } from '../../types/plugin.types';
+import type {
+  JellyfinConfig,
+  JellyfinSession,
+  JellyfinLibrary,
+  JellyfinItemCounts,
+} from '../../types/inputs/jellyfin.types';
+
+const PLAYER_STATE = { PLAYING: 0, PAUSED: 1, BUFFERING: 3 } as const;
+
+/**
+ * Jellyfin input plugin.
+ *
+ * Collects:
+ *   - Active streaming sessions (`GET /Sessions` filtered to those with `NowPlayingItem`)
+ *   - Library metadata (`GET /Library/VirtualFolders`) plus a global item count
+ *     summary (`GET /Items/Counts`)
+ *
+ * Auth uses the `X-Emby-Token` header (legacy name, still the most widely
+ * supported across Jellyfin / Emby forks). Responses are JSON by default.
+ */
+export class JellyfinPlugin extends BaseInputPlugin<JellyfinConfig> {
+  readonly metadata: PluginMetadata = {
+    name: 'Jellyfin',
+    version: '1.0.0',
+    description: 'Collects sessions and library stats from Jellyfin',
+  };
+
+  async initialize(
+    ...args: Parameters<BaseInputPlugin<JellyfinConfig>['initialize']>
+  ): Promise<void> {
+    await super.initialize(...args);
+    this.httpClient.defaults.headers.common['X-Emby-Token'] = this.config.apiKey;
+  }
+
+  protected getHealthEndpoint(): string {
+    return '/System/Info';
+  }
+
+  async collect(): Promise<DataPoint[]> {
+    const points: DataPoint[] = [];
+
+    if (this.config.sessions.enabled) {
+      points.push(...(await this.collectSessions()));
+    }
+
+    if (this.config.libraries.enabled) {
+      points.push(...(await this.collectLibraries()));
+    }
+
+    return points;
+  }
+
+  getSchedules(): ScheduleConfig[] {
+    const schedules: ScheduleConfig[] = [];
+
+    if (this.config.sessions.enabled) {
+      schedules.push(
+        this.createSchedule('sessions', this.config.sessions.intervalSeconds, true, this.collectSessions)
+      );
+    }
+
+    if (this.config.libraries.enabled) {
+      schedules.push(
+        this.createSchedule('libraries', this.config.libraries.intervalSeconds, true, this.collectLibraries)
+      );
+    }
+
+    return schedules;
+  }
+
+  private async collectSessions(): Promise<DataPoint[]> {
+    return this.safeFetch('collect Jellyfin sessions', async () => {
+      const points: DataPoint[] = [];
+      const sessions = await this.httpGet<JellyfinSession[]>('/Sessions');
+      const active = (sessions ?? []).filter((s) => s.NowPlayingItem !== undefined);
+
+      for (const session of active) {
+        points.push(this.processSession(session));
+      }
+
+      points.push(
+        this.createDataPoint(
+          'Jellyfin',
+          {
+            type: 'current_stream_stats',
+            server: this.config.id,
+          },
+          {
+            stream_count: active.length,
+            transcode_streams: active.filter((s) => s.TranscodingInfo !== undefined).length,
+          }
+        )
+      );
+
+      this.logger.info(`Collected ${active.length} Jellyfin sessions`);
+      return points;
+    });
+  }
+
+  private async collectLibraries(): Promise<DataPoint[]> {
+    return this.safeFetch('collect Jellyfin libraries', async () => {
+      const points: DataPoint[] = [];
+
+      const [libraries, counts] = await Promise.all([
+        this.httpGet<JellyfinLibrary[]>('/Library/VirtualFolders'),
+        this.fetchItemCounts(),
+      ]);
+
+      for (const library of libraries ?? []) {
+        points.push(
+          this.createDataPoint(
+            'Jellyfin',
+            {
+              type: 'library_stats',
+              server: this.config.id,
+              section_name: library.Name,
+              section_type: library.CollectionType || 'unknown',
+              name: library.Name,
+            },
+            {
+              locations: library.Locations?.length ?? 0,
+              libraries: library.Name,
+            }
+          )
+        );
+      }
+
+      if (counts) {
+        points.push(
+          this.createDataPoint(
+            'Jellyfin',
+            {
+              type: 'item_counts',
+              server: this.config.id,
+            },
+            {
+              movies: counts.MovieCount,
+              series: counts.SeriesCount,
+              episodes: counts.EpisodeCount,
+              artists: counts.ArtistCount,
+              albums: counts.AlbumCount,
+              songs: counts.SongCount,
+              books: counts.BookCount,
+              box_sets: counts.BoxSetCount,
+              total: counts.ItemCount,
+            }
+          )
+        );
+      }
+
+      this.logger.info(`Collected ${(libraries ?? []).length} Jellyfin libraries`);
+      return points;
+    });
+  }
+
+  /**
+   * Fetch global item counts. Failure is non-fatal — logs debug and returns null
+   * so the libraries collector still emits per-library points.
+   */
+  private async fetchItemCounts(): Promise<JellyfinItemCounts | null> {
+    try {
+      return await this.httpGet<JellyfinItemCounts>('/Items/Counts');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      this.logger.debug(`Could not fetch Jellyfin item counts: ${message}`);
+      return null;
+    }
+  }
+
+  private processSession(session: JellyfinSession): DataPoint {
+    const item = session.NowPlayingItem;
+    const playState = session.PlayState;
+    const transcode = session.TranscodingInfo;
+
+    const playerState = playState?.IsPaused ? PLAYER_STATE.PAUSED : PLAYER_STATE.PLAYING;
+    const videoDecision = transcode ? (transcode.IsVideoDirect ? 'direct stream' : 'transcode') : 'direct play';
+
+    const quality = item?.Height ? `${item.Height}p` : (item?.Container ?? '').toUpperCase() || 'unknown';
+    const fullTitle = item?.SeriesName ? `${item.SeriesName} - ${item?.Name}` : item?.Name || 'unknown';
+
+    const runtimeMs = item?.RunTimeTicks ? item.RunTimeTicks / 10000 : 0;
+    const positionMs = playState?.PositionTicks ? playState.PositionTicks / 10000 : 0;
+    const progressPercent = runtimeMs > 0 ? Math.round((positionMs / runtimeMs) * 100) : 0;
+
+    const hashId = this.hashit(`${session.Id}${session.UserName}${fullTitle}`);
+
+    return this.createDataPoint(
+      'Jellyfin',
+      {
+        type: 'Session',
+        session_id: session.Id,
+        ip_address: session.RemoteEndPoint || 'unknown',
+        username: session.UserName || 'unknown',
+        title: fullTitle,
+        product: session.Client || 'unknown',
+        platform: session.DeviceType || 'unknown',
+        product_version: session.ApplicationVersion || 'unknown',
+        quality,
+        video_decision: videoDecision,
+        media_type: item?.MediaType || item?.Type || 'unknown',
+        audio_codec: (transcode?.AudioCodec || '').toUpperCase() || 'unknown',
+        player_state: playerState,
+        device_type: session.DeviceType || 'unknown',
+        play_method: playState?.PlayMethod || 'unknown',
+        server: this.config.id,
+      },
+      {
+        hash: hashId,
+        progress_percent: progressPercent,
+      }
+    );
+  }
+}

--- a/src/plugins/inputs/index.ts
+++ b/src/plugins/inputs/index.ts
@@ -9,6 +9,7 @@ import { BazarrPlugin } from './BazarrPlugin';
 import { ProwlarrPlugin } from './ProwlarrPlugin';
 import { TautulliPlugin } from './TautulliPlugin';
 import { PlexPlugin } from './PlexPlugin';
+import { JellyfinPlugin } from './JellyfinPlugin';
 import { OverseerrPlugin } from './OverseerrPlugin';
 import { OmbiPlugin } from './OmbiPlugin';
 
@@ -22,6 +23,7 @@ export { BazarrPlugin } from './BazarrPlugin';
 export { ProwlarrPlugin } from './ProwlarrPlugin';
 export { TautulliPlugin } from './TautulliPlugin';
 export { PlexPlugin } from './PlexPlugin';
+export { JellyfinPlugin } from './JellyfinPlugin';
 export { OverseerrPlugin } from './OverseerrPlugin';
 export { OmbiPlugin } from './OmbiPlugin';
 
@@ -38,6 +40,7 @@ const inputPluginClasses: InputPluginFactory[] = [
   ProwlarrPlugin,
   TautulliPlugin,
   PlexPlugin,
+  JellyfinPlugin,
   OverseerrPlugin,
   OmbiPlugin,
 ];

--- a/tests/plugins/inputs/JellyfinPlugin.test.ts
+++ b/tests/plugins/inputs/JellyfinPlugin.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { JellyfinPlugin } from '../../../src/plugins/inputs/JellyfinPlugin';
+import type { JellyfinConfig, JellyfinSession } from '../../../src/types/inputs/jellyfin.types';
+import axios from 'axios';
+import { createMockHttpClient, type MockHttpClient } from '../../fixtures/http';
+
+vi.mock('../../../src/core/Logger', async () => {
+  const { loggerMock } = await import('../../fixtures/logger');
+  return loggerMock();
+});
+
+vi.mock('axios', () => ({ default: { create: vi.fn() } }));
+
+const baseSession: JellyfinSession = {
+  Id: 'sess1',
+  ServerId: 'srv',
+  UserId: 'u1',
+  UserName: 'alice',
+  Client: 'Jellyfin Web',
+  DeviceId: 'dev1',
+  DeviceName: 'Firefox',
+  DeviceType: 'Web',
+  RemoteEndPoint: '10.0.0.1',
+  ApplicationVersion: '10.9.0',
+  IsActive: true,
+  SupportsRemoteControl: false,
+  SupportsMediaControl: true,
+  LastActivityDate: '2026-04-24T00:00:00Z',
+  LastPlaybackCheckIn: '2026-04-24T00:00:00Z',
+  PlayState: {
+    PositionTicks: 2_500_000_000, // 250s
+    CanSeek: true,
+    IsPaused: false,
+    IsMuted: false,
+    PlayMethod: 'DirectPlay',
+    RepeatMode: 'RepeatNone',
+  },
+  NowPlayingItem: {
+    Id: 'item1',
+    ServerId: 'srv',
+    Name: 'Pilot',
+    Type: 'Episode',
+    MediaType: 'Video',
+    RunTimeTicks: 10_000_000_000, // 1000s
+    SeriesName: 'Some Show',
+    Height: 1080,
+    Container: 'mkv',
+  },
+};
+
+describe('JellyfinPlugin', () => {
+  let plugin: JellyfinPlugin;
+  let mockHttpClient: MockHttpClient;
+
+  const testConfig: JellyfinConfig = {
+    id: 1,
+    url: 'http://jellyfin.local:8096',
+    apiKey: 'test-api-key',
+    verifySsl: false,
+    sessions: { enabled: true, intervalSeconds: 30 },
+    libraries: { enabled: true, intervalSeconds: 3600 },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    plugin = new JellyfinPlugin();
+    mockHttpClient = createMockHttpClient();
+    (axios.create as Mock).mockReturnValue(mockHttpClient);
+  });
+
+  describe('metadata', () => {
+    it('exposes correct name and version', () => {
+      expect(plugin.metadata.name).toBe('Jellyfin');
+      expect(plugin.metadata.version).toBe('1.0.0');
+    });
+  });
+
+  describe('initialize', () => {
+    it('sets X-Emby-Token header', async () => {
+      await plugin.initialize(testConfig);
+      expect(mockHttpClient.defaults.headers.common['X-Emby-Token']).toBe('test-api-key');
+    });
+  });
+
+  describe('getSchedules', () => {
+    it('returns enabled schedules only', async () => {
+      await plugin.initialize(testConfig);
+      const schedules = plugin.getSchedules();
+      expect(schedules.map((s) => s.name)).toEqual(['Jellyfin_1_sessions', 'Jellyfin_1_libraries']);
+    });
+
+    it('omits disabled schedules', async () => {
+      await plugin.initialize({ ...testConfig, sessions: { enabled: false, intervalSeconds: 30 } });
+      const schedules = plugin.getSchedules();
+      expect(schedules).toHaveLength(1);
+      expect(schedules[0].name).toBe('Jellyfin_1_libraries');
+    });
+  });
+
+  describe('collect sessions', () => {
+    beforeEach(async () => {
+      await plugin.initialize({ ...testConfig, libraries: { enabled: false, intervalSeconds: 3600 } });
+    });
+
+    it('emits one Session DataPoint per active stream with progress and quality', async () => {
+      mockHttpClient.get.mockResolvedValueOnce({ data: [baseSession] });
+
+      const points = await plugin.collect();
+      const session = points.find((p) => p.tags.type === 'Session');
+
+      expect(session).toBeDefined();
+      expect(session?.tags.username).toBe('alice');
+      expect(session?.tags.title).toBe('Some Show - Pilot');
+      expect(session?.tags.quality).toBe('1080p');
+      expect(session?.fields.progress_percent).toBe(25);
+    });
+
+    it('ignores sessions without NowPlayingItem', async () => {
+      const idleSession = { ...baseSession, NowPlayingItem: undefined, Id: 'idle' };
+      mockHttpClient.get.mockResolvedValueOnce({ data: [idleSession, baseSession] });
+
+      const points = await plugin.collect();
+      const sessionPoints = points.filter((p) => p.tags.type === 'Session');
+      expect(sessionPoints).toHaveLength(1);
+    });
+
+    it('emits a summary point with stream_count and transcode_streams', async () => {
+      const transcoding = {
+        ...baseSession,
+        Id: 'sess2',
+        TranscodingInfo: {
+          AudioCodec: 'aac',
+          VideoCodec: 'h264',
+          Container: 'ts',
+          IsVideoDirect: false,
+          IsAudioDirect: true,
+          Bitrate: 5000000,
+          Width: 1280,
+          Height: 720,
+          AudioChannels: 2,
+          TranscodeReasons: ['VideoCodecNotSupported'],
+        },
+      };
+      mockHttpClient.get.mockResolvedValueOnce({ data: [baseSession, transcoding] });
+
+      const points = await plugin.collect();
+      const summary = points.find((p) => p.tags.type === 'current_stream_stats');
+      expect(summary?.fields.stream_count).toBe(2);
+      expect(summary?.fields.transcode_streams).toBe(1);
+    });
+
+    it('marks paused sessions correctly', async () => {
+      const paused = {
+        ...baseSession,
+        PlayState: { ...baseSession.PlayState!, IsPaused: true },
+      };
+      mockHttpClient.get.mockResolvedValueOnce({ data: [paused] });
+
+      const points = await plugin.collect();
+      const session = points.find((p) => p.tags.type === 'Session');
+      expect(session?.tags.player_state).toBe(1);
+    });
+  });
+
+  describe('collect libraries', () => {
+    beforeEach(async () => {
+      await plugin.initialize({ ...testConfig, sessions: { enabled: false, intervalSeconds: 30 } });
+    });
+
+    it('emits a DataPoint per library plus a global item_counts summary', async () => {
+      mockHttpClient.get
+        .mockResolvedValueOnce({
+          data: [
+            { Name: 'Movies', CollectionType: 'movies', LibraryOptions: {}, ItemId: 'a', Locations: ['/m'] },
+            { Name: 'TV Shows', CollectionType: 'tvshows', LibraryOptions: {}, ItemId: 'b', Locations: ['/tv'] },
+          ],
+        })
+        .mockResolvedValueOnce({
+          data: {
+            MovieCount: 500,
+            SeriesCount: 50,
+            EpisodeCount: 1000,
+            ArtistCount: 0,
+            ProgramCount: 0,
+            TrailerCount: 0,
+            SongCount: 0,
+            AlbumCount: 0,
+            MusicVideoCount: 0,
+            BoxSetCount: 5,
+            BookCount: 0,
+            ItemCount: 1555,
+          },
+        });
+
+      const points = await plugin.collect();
+      const libPoints = points.filter((p) => p.tags.type === 'library_stats');
+      const summary = points.find((p) => p.tags.type === 'item_counts');
+
+      expect(libPoints).toHaveLength(2);
+      expect(libPoints[0].tags.section_name).toBe('Movies');
+      expect(summary?.fields.movies).toBe(500);
+      expect(summary?.fields.total).toBe(1555);
+    });
+
+    it('falls back gracefully when /Items/Counts fails', async () => {
+      mockHttpClient.get
+        .mockResolvedValueOnce({
+          data: [{ Name: 'Movies', CollectionType: 'movies', LibraryOptions: {}, ItemId: 'a', Locations: [] }],
+        })
+        .mockRejectedValueOnce(new Error('counts endpoint 500'));
+
+      const points = await plugin.collect();
+      const libPoints = points.filter((p) => p.tags.type === 'library_stats');
+      const summary = points.find((p) => p.tags.type === 'item_counts');
+
+      expect(libPoints).toHaveLength(1);
+      expect(summary).toBeUndefined();
+    });
+  });
+
+  describe('collect() branches', () => {
+    it('propagates sessions errors via safeFetch', async () => {
+      await plugin.initialize(testConfig);
+      mockHttpClient.get.mockRejectedValueOnce(new Error('jellyfin offline'));
+      await expect(plugin.collect()).rejects.toThrow('jellyfin offline');
+    });
+  });
+});

--- a/tests/plugins/inputs/index.test.ts
+++ b/tests/plugins/inputs/index.test.ts
@@ -10,6 +10,7 @@ import {
   ProwlarrPlugin,
   TautulliPlugin,
   PlexPlugin,
+  JellyfinPlugin,
   OverseerrPlugin,
   OmbiPlugin,
 } from '../../../src/plugins/inputs';
@@ -31,13 +32,14 @@ describe('Input Plugins Index', () => {
       expect(registry.has('prowlarr')).toBe(true);
       expect(registry.has('tautulli')).toBe(true);
       expect(registry.has('plex')).toBe(true);
+      expect(registry.has('jellyfin')).toBe(true);
       expect(registry.has('overseerr')).toBe(true);
       expect(registry.has('ombi')).toBe(true);
     });
 
     it('should have correct number of plugins', () => {
       const registry = getInputPluginRegistry();
-      expect(registry.size).toBe(10);
+      expect(registry.size).toBe(11);
     });
 
     it('should return plugin classes that can be instantiated', () => {
@@ -97,6 +99,10 @@ describe('Input Plugins Index', () => {
 
     it('should export PlexPlugin', () => {
       expect(PlexPlugin).toBeDefined();
+    });
+
+    it('should export JellyfinPlugin', () => {
+      expect(JellyfinPlugin).toBeDefined();
     });
 
     it('should export OverseerrPlugin', () => {


### PR DESCRIPTION
## Description

Adds `JellyfinPlugin` — direct Jellyfin API integration parallel to `PlexPlugin`. Produces sessions + library metrics for Grafana dashboards.

### Collected data

- **Sessions** (`GET /Sessions`) — only sessions with a `NowPlayingItem` are counted as active streams. Each emits a DataPoint with username, title (SeriesName + item name for episodes), quality (height or container), decision (direct play / direct stream / transcode), media type, player state (playing/paused), and progress %. A summary point carries `stream_count` and `transcode_streams`.
- **Libraries** (`GET /Library/VirtualFolders`) — one DataPoint per library with name and `CollectionType`.
- **Global item counts** (`GET /Items/Counts`) — one summary point with movies / series / episodes / albums / songs / books / box sets / total.

### Implementation notes

- **Auth:** `X-Emby-Token` header, set in `initialize`. Chosen over `Authorization: MediaBrowser …` because it's more compatible with Emby forks out of the box.
- **Progress %:** Jellyfin uses 100-ns ticks for `RunTimeTicks` and `PositionTicks`. Converted to ms and rounded to an integer percent.
- **Graceful degradation:** if `/Items/Counts` fails, per-library points still emit; the summary is just omitted.

### Testing

- 11 new unit tests: init header, schedule gating, session shape + progress, summary counting (active streams, transcodes), paused player state mapping, library + counts happy path, counts failure fallback, safeFetch error propagation
- Registry test updated: now expects 11 input plugins

### Coverage

- `JellyfinPlugin.ts`: **98.15%**
- Global: 91.38% → **91.54%**

## Type of change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [ ] Dependencies update

## Checklist
- [x] I have tested my changes locally
- [x] I have added/updated tests if needed (+12)
- [x] Code coverage is maintained or improved
- [x] Lint passes (`npm run lint`)
- [x] Tests pass (`npm test`) — 700 passed

## Related

Continues Phase 9 (Additional Input Plugins). Only Emby remains.