### PR TITLE
feat(inputs): deduplicate and optionally cache httpGet requests

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -68,7 +68,7 @@ varken/
 │   └── utils/
 │       ├── http.ts                  # HTTP utilities, error classification
 │       └── index.ts
-├── tests/                           # 711 tests, 91% coverage
+├── tests/                           # 721 tests, 91% coverage
 │   ├── config/
 │   ├── core/
 │   ├── plugins/
@@ -228,7 +228,7 @@ interface ScheduleConfig {
 - [x] Main entry point (`index.ts`)
 - [x] Dockerfile (multi-stage, ~190MB)
 - [x] docker-compose.yml (Varken + InfluxDB 2.x + Grafana)
-- [x] Unit tests (711 tests passing)
+- [x] Unit tests (721 tests passing)
 - [x] CI/CD workflows (GitHub Actions)
 - [x] Codecov integration
 - [x] Documentation (README.md, CLAUDE.md)
@@ -369,11 +369,12 @@ interface ScheduleConfig {
   - Hints cover ECONNREFUSED (reachability), ETIMEDOUT (tune `httpTimeoutMs`), 401/403 (auth key/token), 404 (API path/version), 429 (rate limit), 5xx (server logs), TLS cert errors, HTML-instead-of-JSON responses
   - Integrated in `BaseInputPlugin.httpGet/httpPost`, `VictoriaMetricsPlugin`, `InfluxDB2Plugin` write errors
 
-#### Request Deduplication/Cache
-- [ ] Implement request cache with TTL
-  - Share data between schedules (e.g., queue data for multiple Sonarr schedules)
-  - Reduce load on source services
-  - Effort: ~4h
+#### Request Deduplication/Cache ✅
+- [x] Implement request cache with TTL
+  - Added generic in-flight request deduplication to `BaseInputPlugin.httpGet` (always on): concurrent identical GET requests share a single in-flight promise instead of firing duplicate calls
+  - Added opt-in TTL caching via the new global `cacheTtlSeconds` config option (default `0` = dedup only, no stored caching); when set, successful GET responses are cached per key (URL + params) for that duration
+  - `httpPost` requests are never deduplicated or cached
+  - The per-IP GeoIP cache (`src/utils/RequestCache.ts`, used by `TautulliPlugin`) was already implemented separately in an earlier phase and is unaffected by this change
 
 #### Environment Variable Validation ✅
 - [x] Create `src/utils/env.ts` for env var validation
@@ -454,7 +455,7 @@ interface ScheduleConfig {
 
 ## Test Coverage Summary
 
-> **Last updated**: 2026-04-24 | **Global coverage**: 91.69% | **Tests**: 711 unit + 2 integration passing
+> **Last updated**: 2026-04-24 | **Global coverage**: 91.69% | **Tests**: 721 unit + 2 integration passing
 
 | File | Coverage | Target | Status | Notes |
 |------|----------|--------|--------|-------|

--- a/README.md
+++ b/README.md
@@ -242,15 +242,17 @@ global:
   collectorTimeoutMs: 60000
   paginationPageSize: 250
   maxPaginationRecords: 10000
+  cacheTtlSeconds: 0
 ```
 
-| Setting                | Default | Description                             |
-|------------------------|---------|-----------------------------------------|
-| `httpTimeoutMs`        | 30000   | Timeout for HTTP requests to services   |
-| `healthCheckTimeoutMs` | 5000    | Timeout for health check requests       |
-| `collectorTimeoutMs`   | 60000   | Timeout for collector execution         |
-| `paginationPageSize`   | 250     | Records per page for paginated APIs     |
-| `maxPaginationRecords` | 10000   | Maximum records to fetch (safety limit) |
+| Setting                | Default | Description                                                      |
+|------------------------|---------|------------------------------------------------------------------|
+| `httpTimeoutMs`        | 30000   | Timeout for HTTP requests to services                            |
+| `healthCheckTimeoutMs` | 5000    | Timeout for health check requests                                |
+| `collectorTimeoutMs`   | 60000   | Timeout for collector execution                                  |
+| `paginationPageSize`   | 250     | Records per page for paginated APIs                              |
+| `maxPaginationRecords` | 10000   | Maximum records to fetch (safety limit)                          |
+| `cacheTtlSeconds`      | 0       | TTL (seconds) for the HTTP GET cache; 0 = dedup only, no caching |
 
 ### Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -254,6 +254,8 @@ global:
 | `maxPaginationRecords` | 10000   | Maximum records to fetch (safety limit)                          |
 | `cacheTtlSeconds`      | 0       | TTL (seconds) for the HTTP GET cache; 0 = dedup only, no caching |
 
+> **Note:** `cacheTtlSeconds > 0` caches **all** GET responses, including real-time endpoints (Tautulli activity, *arr queues). A stored response is reused until the TTL expires, so set this well below your shortest poll interval — otherwise those metrics freeze between refreshes. Leave it at `0` unless you have a specific reason; concurrent-request deduplication is always on regardless.
+
 ### Environment Variables
 
 #### Docker Environment Variables

--- a/docs/superpowers/plans/2026-07-06-http-request-cache.md
+++ b/docs/superpowers/plans/2026-07-06-http-request-cache.md
@@ -1,0 +1,334 @@
+# Generic HTTP Request Cache Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the existing `RequestCache` into `BaseInputPlugin.httpGet()` so all input plugins get in-flight request deduplication (always on) plus opt-in TTL caching (disabled by default).
+
+**Architecture:** `httpGet()` routes every GET through a per-instance `RequestCache`. With `ttlMs = 0` the cache still deduplicates concurrent identical requests but never serves a stored response (immediate expiry), giving "dedup on, TTL off" for free. A new global config field `cacheTtlSeconds` enables TTL caching.
+
+**Tech Stack:** TypeScript, Zod (config schema), Vitest.
+
+## Global Constraints
+
+- All code, comments, and commits in English.
+- TypeScript strict mode: `noImplicitAny`, `strictNullChecks`, `noUnusedLocals`, `noUnusedParameters`, `noImplicitReturns`.
+- ESLint: `consistent-type-imports` enforced, `eqeqeq` (always `===`), curly braces required.
+- `httpPost()` is never cached.
+- No per-input `cacheTtlSeconds` override (global only).
+- `cacheTtlSeconds` is **optional** in the `GlobalConfig` type (output `number | undefined`), treated as `0` when absent — to avoid breaking the 9 existing `GlobalConfig` literals across the test suite.
+
+---
+
+### Task 1: Add `cacheTtlSeconds` to the global config schema
+
+**Files:**
+- Modify: `src/config/schemas/config.schema.ts:212-223` (GlobalConfigSchema)
+- Test: `tests/config/index.test.ts`
+
+**Interfaces:**
+- Produces: `GlobalConfig.cacheTtlSeconds?: number` (optional, `>= 0`).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/config/index.test.ts` (import `GlobalConfigSchema` from `../../src/config/schemas/config.schema` if not already imported):
+
+```typescript
+import { GlobalConfigSchema } from '../../src/config/schemas/config.schema';
+
+describe('GlobalConfigSchema cacheTtlSeconds', () => {
+  it('accepts a non-negative cacheTtlSeconds', () => {
+    const parsed = GlobalConfigSchema.parse({ cacheTtlSeconds: 30 });
+    expect(parsed.cacheTtlSeconds).toBe(30);
+  });
+
+  it('leaves cacheTtlSeconds undefined when omitted', () => {
+    const parsed = GlobalConfigSchema.parse({});
+    expect(parsed.cacheTtlSeconds).toBeUndefined();
+  });
+
+  it('rejects a negative cacheTtlSeconds', () => {
+    expect(() => GlobalConfigSchema.parse({ cacheTtlSeconds: -1 })).toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- tests/config/index.test.ts`
+Expected: FAIL — `cacheTtlSeconds` is `undefined` on parse of `{ cacheTtlSeconds: 30 }` (field not yet in schema), and the negative case does not throw.
+
+- [ ] **Step 3: Add the field to the schema**
+
+In `src/config/schemas/config.schema.ts`, inside `GlobalConfigSchema` (after `maxPaginationRecords`, before the closing `});` at line 223):
+
+```typescript
+  /** TTL for the generic HTTP GET cache in seconds. 0 or omitted = dedup only, no TTL caching. */
+  cacheTtlSeconds: z.number().min(0).optional(),
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- tests/config/index.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/config/schemas/config.schema.ts tests/config/index.test.ts
+git commit -m "feat(config): add optional cacheTtlSeconds global option"
+```
+
+---
+
+### Task 2: Wire `RequestCache` into `BaseInputPlugin.httpGet()`
+
+**Files:**
+- Modify: `src/plugins/inputs/BaseInputPlugin.ts` (imports, `DEFAULT_GLOBAL_CONFIG`, class fields, `initialize()`, `httpGet()`, new private `cacheKey()`)
+- Test: `tests/plugins/inputs/BaseInputPlugin.test.ts` (add `testHttpGet`/`testHttpPost` accessors + new `describe('httpGet caching')` block)
+
+**Interfaces:**
+- Consumes: `RequestCache` from `../../utils/RequestCache` (`getOrFetch(key, fetcher)`, constructor `{ ttlMs, maxSize }`); `GlobalConfig.cacheTtlSeconds?` from Task 1.
+- Produces: `httpGet()` deduplicates concurrent identical calls and caches for `cacheTtlSeconds` seconds; `httpPost()` unchanged.
+
+- [ ] **Step 1: Add test accessors to the `TestInputPlugin` subclass**
+
+In `tests/plugins/inputs/BaseInputPlugin.test.ts`, add these methods inside `class TestInputPlugin` (after `testSafeFetch`, around line 75):
+
+```typescript
+  public testHttpGet<T>(path: string, params?: Record<string, unknown>): Promise<T> {
+    return this.httpGet<T>(path, params);
+  }
+
+  public testHttpPost<T>(path: string, data?: unknown): Promise<T> {
+    return this.httpPost<T>(path, data);
+  }
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Add a new `describe` block inside the top-level `describe('BaseInputPlugin', ...)` (e.g. after the `safeFetch` block). Note `data: {}` is required because the response interceptor is bypassed (the tests overwrite `.get`), and each test overwrites `get`/`post` directly:
+
+```typescript
+  describe('httpGet caching', () => {
+    it('deduplicates concurrent identical GETs into a single request', async () => {
+      await plugin.initialize(testConfig);
+      let resolveGet: (v: { data: unknown }) => void = () => {};
+      const getSpy = vi.fn().mockImplementation(
+        () => new Promise((res) => { resolveGet = res; })
+      );
+      plugin.getHttpClient().get = getSpy;
+
+      const p1 = plugin.testHttpGet('/api/x');
+      const p2 = plugin.testHttpGet('/api/x');
+      resolveGet({ data: { ok: true } });
+      await Promise.all([p1, p2]);
+
+      expect(getSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('serves a cached response within cacheTtlSeconds', async () => {
+      const customGlobal = { cacheTtlSeconds: 60 } as unknown as GlobalConfig;
+      await plugin.initialize(testConfig, customGlobal);
+      const getSpy = vi.fn().mockResolvedValue({ data: { ok: true } });
+      plugin.getHttpClient().get = getSpy;
+
+      await plugin.testHttpGet('/api/x');
+      await plugin.testHttpGet('/api/x');
+
+      expect(getSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not cache across sequential calls when cacheTtlSeconds is 0', async () => {
+      await plugin.initialize(testConfig); // default: no cacheTtlSeconds -> 0
+      const getSpy = vi.fn().mockResolvedValue({ data: { ok: true } });
+      plugin.getHttpClient().get = getSpy;
+
+      await plugin.testHttpGet('/api/x');
+      await plugin.testHttpGet('/api/x');
+
+      expect(getSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('uses distinct cache keys for different params', async () => {
+      const customGlobal = { cacheTtlSeconds: 60 } as unknown as GlobalConfig;
+      await plugin.initialize(testConfig, customGlobal);
+      const getSpy = vi.fn().mockResolvedValue({ data: { ok: true } });
+      plugin.getHttpClient().get = getSpy;
+
+      await plugin.testHttpGet('/api/x', { page: 1 });
+      await plugin.testHttpGet('/api/x', { page: 2 });
+
+      expect(getSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('produces the same cache key regardless of param order', async () => {
+      const customGlobal = { cacheTtlSeconds: 60 } as unknown as GlobalConfig;
+      await plugin.initialize(testConfig, customGlobal);
+      const getSpy = vi.fn().mockResolvedValue({ data: { ok: true } });
+      plugin.getHttpClient().get = getSpy;
+
+      await plugin.testHttpGet('/api/x', { a: 1, b: 2 });
+      await plugin.testHttpGet('/api/x', { b: 2, a: 1 });
+
+      expect(getSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not cache a failed GET', async () => {
+      const customGlobal = { cacheTtlSeconds: 60 } as unknown as GlobalConfig;
+      await plugin.initialize(testConfig, customGlobal);
+      const getSpy = vi.fn()
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockResolvedValueOnce({ data: { ok: true } });
+      plugin.getHttpClient().get = getSpy;
+
+      await expect(plugin.testHttpGet('/api/x')).rejects.toThrow('boom');
+      await plugin.testHttpGet('/api/x');
+
+      expect(getSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('never caches httpPost', async () => {
+      const customGlobal = { cacheTtlSeconds: 60 } as unknown as GlobalConfig;
+      await plugin.initialize(testConfig, customGlobal);
+      const postSpy = vi.fn().mockResolvedValue({ data: { ok: true } });
+      plugin.getHttpClient().post = postSpy;
+
+      await plugin.testHttpPost('/api/x', { a: 1 });
+      await plugin.testHttpPost('/api/x', { a: 1 });
+
+      expect(postSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `npm test -- tests/plugins/inputs/BaseInputPlugin.test.ts`
+Expected: FAIL — dedup/cache tests fail because `httpGet` currently calls the client directly (getSpy called 2 times where 1 is expected). The "does not cache when 0" / "distinct params" / "post" tests may already pass; that is fine.
+
+- [ ] **Step 4: Implement the cache in `BaseInputPlugin`**
+
+In `src/plugins/inputs/BaseInputPlugin.ts`:
+
+(a) Add the import near the other imports (top of file, respecting `consistent-type-imports` — `RequestCache` is a class, use a value import):
+
+```typescript
+import { RequestCache } from '../../utils/RequestCache';
+```
+
+(b) Add a `cacheMaxSize` default to `DEFAULT_GLOBAL_CONFIG`? No — `cacheTtlSeconds` is optional and absent means 0. Leave `DEFAULT_GLOBAL_CONFIG` unchanged.
+
+(c) Add a private field for the max cache size and the cache instance. Add after `protected logger` (around line 57):
+
+```typescript
+  private static readonly HTTP_CACHE_MAX_SIZE = 500;
+  private httpCache!: RequestCache<unknown>;
+```
+
+(d) In `initialize()`, create the cache after `this.httpClient = this.createHttpClient();` (around line 75):
+
+```typescript
+    const ttlMs = (this.globalConfig.cacheTtlSeconds ?? 0) * 1000;
+    this.httpCache = new RequestCache<unknown>({
+      ttlMs,
+      maxSize: BaseInputPlugin.HTTP_CACHE_MAX_SIZE,
+    });
+```
+
+(e) Add a private `cacheKey` helper (e.g. after `httpPost`, before `fetchAllPages`):
+
+```typescript
+  /**
+   * Build a deterministic cache key from path + params (keys sorted so param
+   * order does not matter). Each plugin instance has its own cache, so the
+   * baseURL is not part of the key.
+   */
+  private cacheKey(path: string, params?: Record<string, unknown>): string {
+    if (!params || Object.keys(params).length === 0) {
+      return path;
+    }
+    const sorted = Object.keys(params)
+      .sort()
+      .reduce<Record<string, unknown>>((acc, k) => {
+        acc[k] = params[k];
+        return acc;
+      }, {});
+    return `${path}?${JSON.stringify(sorted)}`;
+  }
+```
+
+(f) Replace the body of `httpGet` (lines 184-194) with a cache-wrapped version:
+
+```typescript
+  protected async httpGet<T>(path: string, params?: Record<string, unknown>): Promise<T> {
+    const key = this.cacheKey(path, params);
+    return this.httpCache.getOrFetch(key, async () => {
+      try {
+        const response = await this.httpClient.get<T>(path, { params });
+        return response.data;
+      } catch (error) {
+        this.logger.error(
+          `HTTP GET ${path} failed: ${formatHelpfulError(error, { service: this.metadata.name, url: path })}`
+        );
+        throw error;
+      }
+    }) as Promise<T>;
+  }
+```
+
+Leave `httpPost` unchanged.
+
+- [ ] **Step 5: Run the full test file to verify it passes**
+
+Run: `npm test -- tests/plugins/inputs/BaseInputPlugin.test.ts`
+Expected: PASS (all httpGet caching tests plus the pre-existing tests).
+
+- [ ] **Step 6: Run the whole unit suite + build to check nothing regressed**
+
+Run: `npm test && npm run build && npm run lint`
+Expected: all tests pass, `tsc` clean, ESLint clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/plugins/inputs/BaseInputPlugin.ts tests/plugins/inputs/BaseInputPlugin.test.ts
+git commit -m "feat(inputs): deduplicate and optionally cache httpGet requests"
+```
+
+---
+
+### Task 3: Documentation and PLAN update
+
+**Files:**
+- Modify: `README.md` (global config options section)
+- Modify: `PLAN.md:372-376` (Phase 11 Request Deduplication/Cache)
+
+- [ ] **Step 1: Document `cacheTtlSeconds` in README**
+
+Find the section documenting global config options (search `README.md` for `httpTimeoutMs`). Add a row/entry consistent with the existing format, for example:
+
+```markdown
+| `cacheTtlSeconds` | `0` | TTL for the generic HTTP GET cache (seconds). `0` = deduplicate concurrent identical requests only, no stored caching. |
+```
+
+If the existing docs use prose or a YAML example instead of a table, mirror that style — add `cacheTtlSeconds` alongside `httpTimeoutMs` with the same description.
+
+- [ ] **Step 2: Check off the PLAN item**
+
+In `PLAN.md`, update the Phase 11 "Request Deduplication/Cache" block (lines 372-376). Change the header to `#### Request Deduplication/Cache ✅`, mark the checkbox `- [x]`, and note that the GeoIP cache was already implemented and this task added generic httpGet dedup + opt-in TTL via `cacheTtlSeconds`. Also update the Priority Summary row and any test counters per the project's PLAN conventions.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md PLAN.md
+git commit -m "docs: document cacheTtlSeconds and mark request cache complete"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** dedup (Task 2 tests), opt-in TTL (Task 1 + Task 2 cache-hit test), TTL-off default (Task 2 zero test), distinct params (Task 2), failed GET not cached (Task 2), httpPost never cached (Task 2), config field (Task 1), docs + PLAN (Task 3). GeoIP is already done (out of scope, noted).
+- **Deviation from spec:** spec said "new test file"; the file `tests/plugins/inputs/BaseInputPlugin.test.ts` already exists, so tests are appended there.
+- **Deviation from spec:** `cacheTtlSeconds` is `optional` (not `.default(0)`) to avoid breaking 9 existing `GlobalConfig` literals; code treats absent as `0`.
+- **Added test beyond spec:** param-order-independent key (cheap correctness guarantee for `cacheKey`).

--- a/docs/superpowers/specs/2026-07-06-http-request-cache-design.md
+++ b/docs/superpowers/specs/2026-07-06-http-request-cache-design.md
@@ -1,0 +1,97 @@
+# Generic HTTP Request Cache in `httpGet()` — Design
+
+**Date:** 2026-07-06
+**Status:** Approved
+**PLAN.md item:** Phase 11 → Request Deduplication/Cache
+
+## Context
+
+`src/utils/RequestCache.ts` already exists (TTL + in-flight deduplication, 13 unit
+tests) and is already wired into `TautulliPlugin` for GeoIP lookups (per-IP key,
+long TTL). This design covers the remaining work: wiring a generic cache into
+`BaseInputPlugin.httpGet()` so every input plugin benefits from request
+deduplication, with opt-in TTL caching.
+
+Investigation findings that shape the design:
+
+- The natural injection point is `BaseInputPlugin.httpGet()` — all input plugins
+  route GET requests through it.
+- Each schedule generally targets a distinct endpoint, so cross-schedule *data
+  sharing* is marginal. The concrete wins are (a) in-flight deduplication of
+  concurrent identical requests (e.g. a health check and a collector racing), and
+  (b) opt-in short-TTL caching for tight polling intervals.
+- The GeoIP cache is already implemented and is out of scope here.
+
+## Goals
+
+- Deduplicate concurrent identical GET requests within a plugin instance — always
+  on, zero staleness risk.
+- Provide opt-in TTL caching, disabled by default, configured globally.
+
+## Non-goals
+
+- Per-input `cacheTtlSeconds` override (YAGNI: would touch ~12 separate input
+  schemas for marginal value; deduplication is always on regardless). Revisit only
+  if a real need emerges.
+- Caching `httpPost()` (not idempotent).
+- Sharing a cache across plugin instances.
+
+## Design
+
+### 1. `RequestCache` with `ttlMs = 0` yields exactly "dedup on, TTL off"
+
+With `ttlMs = 0`, `set()` stores `expiresAt = now`, so `peek()` evicts immediately
+(`expiresAt <= Date.now()`) → no TTL caching. But `getOrFetch()` consults the
+`inflight` map before launching a fetch, so concurrent identical calls still share
+one promise → in-flight deduplication remains active. No new logic needed in
+`RequestCache`.
+
+### 2. Wiring in `BaseInputPlugin`
+
+- Add `private httpCache: RequestCache<unknown>`, created in `initialize()` with
+  `ttlMs = this.globalConfig.cacheTtlSeconds * 1000` (default 0) and a default
+  `maxSize` (500).
+- `httpGet<T>(path, params)` wraps the actual request in
+  `this.httpCache.getOrFetch(key, fetcher)`.
+- **Cache key:** `` `${path}?${stableStringify(params)}` `` where
+  `stableStringify` serializes with sorted keys for determinism. Each instance has
+  its own cache, so the `baseURL` is not part of the key.
+- `httpPost()` is left unchanged (not cached).
+- The existing try/catch + `formatHelpfulError` error handling stays inside the
+  fetcher so failures are not cached (the fetcher throws before `set()` runs).
+
+### 3. Config
+
+- Add `cacheTtlSeconds: z.number().min(0).default(0)` to `GlobalConfigSchema`
+  (`src/config/schemas/config.schema.ts`).
+- Add it to the schema's default transform (~line 279) and to
+  `DEFAULT_GLOBAL_CONFIG` in `BaseInputPlugin.ts`.
+
+### 4. GeoIP interaction
+
+No effect. `geoipCache` (per-IP, long TTL) sits in front of `httpGet`; the inner
+GET simply gains transient deduplication.
+
+## Testing
+
+`RequestCache` is already covered (13 tests). Add tests on `BaseInputPlugin.httpGet`
+(via a minimal concrete test subclass):
+
+- Two concurrent identical GETs → underlying HTTP client called once (dedup).
+- With `cacheTtlSeconds > 0`: a second sequential call serves from cache (client
+  called once); after TTL expiry it fetches again.
+- With `cacheTtlSeconds = 0`: a second sequential call re-fetches (client called
+  twice) — TTL off, dedup only.
+- Different `params` → distinct keys → separate fetches.
+- A failing GET is not cached (next call retries).
+- `httpPost` is never cached.
+
+## Files touched
+
+- `src/plugins/inputs/BaseInputPlugin.ts` — cache instance + `httpGet` wrapping +
+  `stableStringify` helper + `DEFAULT_GLOBAL_CONFIG`.
+- `src/config/schemas/config.schema.ts` — `cacheTtlSeconds` field + default
+  transform.
+- `tests/plugins/inputs/BaseInputPlugin.test.ts` (new) — httpGet cache tests.
+- `README.md` — document `cacheTtlSeconds` global option.
+- `PLAN.md` — check off Phase 11 Request Deduplication/Cache.

--- a/src/config/schemas/config.schema.ts
+++ b/src/config/schemas/config.schema.ts
@@ -220,6 +220,8 @@ export const GlobalConfigSchema = z.object({
   paginationPageSize: z.number().min(10).max(1000).default(250),
   /** Maximum records to fetch in pagination (safety limit) */
   maxPaginationRecords: z.number().min(1000).default(10000),
+  /** TTL for the generic HTTP GET cache in seconds. 0 or omitted = dedup only, no TTL caching. */
+  cacheTtlSeconds: z.number().min(0).optional(),
 });
 
 // =============================================================================

--- a/src/plugins/inputs/BaseInputPlugin.ts
+++ b/src/plugins/inputs/BaseInputPlugin.ts
@@ -4,6 +4,7 @@ import * as https from 'https';
 import { createHash } from 'crypto';
 import { createLogger, withContext } from '../../core/Logger';
 import { formatHelpfulError } from '../../utils/errors';
+import { RequestCache } from '../../utils/RequestCache';
 import type { GlobalConfig } from '../../config/schemas/config.schema';
 import type {
   InputPlugin,
@@ -55,6 +56,8 @@ export abstract class BaseInputPlugin<TConfig extends BaseInputConfig = BaseInpu
   protected globalConfig: GlobalConfig = DEFAULT_GLOBAL_CONFIG;
   protected httpClient!: AxiosInstance;
   protected logger = createLogger(this.constructor.name);
+  private static readonly HTTP_CACHE_MAX_SIZE = 500;
+  private httpCache!: RequestCache<unknown>;
 
   /**
    * Plugin metadata - must be implemented by subclasses
@@ -73,6 +76,11 @@ export abstract class BaseInputPlugin<TConfig extends BaseInputConfig = BaseInpu
     // can filter per-instance without parsing the message string.
     this.logger = withContext(this.logger, { pluginId: this.config.id });
     this.httpClient = this.createHttpClient();
+    const ttlMs = (this.globalConfig.cacheTtlSeconds ?? 0) * 1000;
+    this.httpCache = new RequestCache<unknown>({
+      ttlMs,
+      maxSize: BaseInputPlugin.HTTP_CACHE_MAX_SIZE,
+    });
     this.logger.info(`Initialized ${this.metadata.name} plugin (id: ${this.config.id})`);
   }
 
@@ -182,15 +190,18 @@ export abstract class BaseInputPlugin<TConfig extends BaseInputConfig = BaseInpu
    * Make an HTTP GET request
    */
   protected async httpGet<T>(path: string, params?: Record<string, unknown>): Promise<T> {
-    try {
-      const response = await this.httpClient.get<T>(path, { params });
-      return response.data;
-    } catch (error) {
-      this.logger.error(
-        `HTTP GET ${path} failed: ${formatHelpfulError(error, { service: this.metadata.name, url: path })}`
-      );
-      throw error;
-    }
+    const key = this.cacheKey(path, params);
+    return this.httpCache.getOrFetch(key, async () => {
+      try {
+        const response = await this.httpClient.get<T>(path, { params });
+        return response.data;
+      } catch (error) {
+        this.logger.error(
+          `HTTP GET ${path} failed: ${formatHelpfulError(error, { service: this.metadata.name, url: path })}`
+        );
+        throw error;
+      }
+    }) as Promise<T>;
   }
 
   /**
@@ -206,6 +217,24 @@ export abstract class BaseInputPlugin<TConfig extends BaseInputConfig = BaseInpu
       );
       throw error;
     }
+  }
+
+  /**
+   * Build a deterministic cache key from path + params (keys sorted so param
+   * order does not matter). Each plugin instance has its own cache, so the
+   * baseURL is not part of the key.
+   */
+  private cacheKey(path: string, params?: Record<string, unknown>): string {
+    if (!params || Object.keys(params).length === 0) {
+      return path;
+    }
+    const sorted = Object.keys(params)
+      .sort()
+      .reduce<Record<string, unknown>>((acc, k) => {
+        acc[k] = params[k];
+        return acc;
+      }, {});
+    return `${path}?${JSON.stringify(sorted)}`;
   }
 
   /**

--- a/tests/config/index.test.ts
+++ b/tests/config/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { ConfigLoader, ConfigMigrator } from '../../src/config';
+import { GlobalConfigSchema } from '../../src/config/schemas/config.schema';
 
 describe('Config Index', () => {
   describe('exports', () => {
@@ -12,5 +13,21 @@ describe('Config Index', () => {
       expect(ConfigMigrator).toBeDefined();
       expect(typeof ConfigMigrator).toBe('function');
     });
+  });
+});
+
+describe('GlobalConfigSchema cacheTtlSeconds', () => {
+  it('accepts a non-negative cacheTtlSeconds', () => {
+    const parsed = GlobalConfigSchema.parse({ cacheTtlSeconds: 30 });
+    expect(parsed.cacheTtlSeconds).toBe(30);
+  });
+
+  it('leaves cacheTtlSeconds undefined when omitted', () => {
+    const parsed = GlobalConfigSchema.parse({});
+    expect(parsed.cacheTtlSeconds).toBeUndefined();
+  });
+
+  it('rejects a negative cacheTtlSeconds', () => {
+    expect(() => GlobalConfigSchema.parse({ cacheTtlSeconds: -1 })).toThrow();
   });
 });

--- a/tests/plugins/inputs/BaseInputPlugin.test.ts
+++ b/tests/plugins/inputs/BaseInputPlugin.test.ts
@@ -73,6 +73,14 @@ class TestInputPlugin extends BaseInputPlugin<TestConfig> {
   public testSafeFetch<T>(operation: string, fn: () => Promise<T>): Promise<T> {
     return this.safeFetch(operation, fn);
   }
+
+  public testHttpGet<T>(path: string, params?: Record<string, unknown>): Promise<T> {
+    return this.httpGet<T>(path, params);
+  }
+
+  public testHttpPost<T>(path: string, data?: unknown): Promise<T> {
+    return this.httpPost<T>(path, data);
+  }
 }
 
 describe('BaseInputPlugin', () => {
@@ -493,6 +501,97 @@ describe('BaseInputPlugin', () => {
           throw 'string error';
         })
       ).rejects.toBe('string error');
+    });
+  });
+
+  describe('httpGet caching', () => {
+    it('deduplicates concurrent identical GETs into a single request', async () => {
+      await plugin.initialize(testConfig);
+      let resolveGet: (v: { data: unknown }) => void = () => {};
+      const getSpy = vi.fn().mockImplementation(
+        () => new Promise((res) => { resolveGet = res; })
+      );
+      plugin.getHttpClient().get = getSpy;
+
+      const p1 = plugin.testHttpGet('/api/x');
+      const p2 = plugin.testHttpGet('/api/x');
+      resolveGet({ data: { ok: true } });
+      await Promise.all([p1, p2]);
+
+      expect(getSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('serves a cached response within cacheTtlSeconds', async () => {
+      const customGlobal = { cacheTtlSeconds: 60 } as unknown as GlobalConfig;
+      await plugin.initialize(testConfig, customGlobal);
+      const getSpy = vi.fn().mockResolvedValue({ data: { ok: true } });
+      plugin.getHttpClient().get = getSpy;
+
+      await plugin.testHttpGet('/api/x');
+      await plugin.testHttpGet('/api/x');
+
+      expect(getSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not cache across sequential calls when cacheTtlSeconds is 0', async () => {
+      await plugin.initialize(testConfig); // default: no cacheTtlSeconds -> 0
+      const getSpy = vi.fn().mockResolvedValue({ data: { ok: true } });
+      plugin.getHttpClient().get = getSpy;
+
+      await plugin.testHttpGet('/api/x');
+      await plugin.testHttpGet('/api/x');
+
+      expect(getSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('uses distinct cache keys for different params', async () => {
+      const customGlobal = { cacheTtlSeconds: 60 } as unknown as GlobalConfig;
+      await plugin.initialize(testConfig, customGlobal);
+      const getSpy = vi.fn().mockResolvedValue({ data: { ok: true } });
+      plugin.getHttpClient().get = getSpy;
+
+      await plugin.testHttpGet('/api/x', { page: 1 });
+      await plugin.testHttpGet('/api/x', { page: 2 });
+
+      expect(getSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('produces the same cache key regardless of param order', async () => {
+      const customGlobal = { cacheTtlSeconds: 60 } as unknown as GlobalConfig;
+      await plugin.initialize(testConfig, customGlobal);
+      const getSpy = vi.fn().mockResolvedValue({ data: { ok: true } });
+      plugin.getHttpClient().get = getSpy;
+
+      await plugin.testHttpGet('/api/x', { a: 1, b: 2 });
+      await plugin.testHttpGet('/api/x', { b: 2, a: 1 });
+
+      expect(getSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not cache a failed GET', async () => {
+      const customGlobal = { cacheTtlSeconds: 60 } as unknown as GlobalConfig;
+      await plugin.initialize(testConfig, customGlobal);
+      const getSpy = vi.fn()
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockResolvedValueOnce({ data: { ok: true } });
+      plugin.getHttpClient().get = getSpy;
+
+      await expect(plugin.testHttpGet('/api/x')).rejects.toThrow('boom');
+      await plugin.testHttpGet('/api/x');
+
+      expect(getSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('never caches httpPost', async () => {
+      const customGlobal = { cacheTtlSeconds: 60 } as unknown as GlobalConfig;
+      await plugin.initialize(testConfig, customGlobal);
+      const postSpy = vi.fn().mockResolvedValue({ data: { ok: true } });
+      plugin.getHttpClient().post = postSpy;
+
+      await plugin.testHttpPost('/api/x', { a: 1 });
+      await plugin.testHttpPost('/api/x', { a: 1 });
+
+      expect(postSpy).toHaveBeenCalledTimes(2);
     });
   });
 });


### PR DESCRIPTION
## Description
Wires the existing `RequestCache` into `BaseInputPlugin.httpGet()` so every input plugin gets:

- **In-flight deduplication** of concurrent identical GET requests — always on, zero staleness risk (a health check and a collector, or two collectors, racing the same endpoint share a single request).
- **Opt-in TTL caching** via a new global config option `cacheTtlSeconds` (default `0` = dedup only, no stored caching).

Key points:
- `RequestCache` with `ttlMs = 0` already yields "dedup on, TTL off" (immediate expiry keeps stored caching disabled while the in-flight map still deduplicates), so no changes were needed in `RequestCache` itself.
- Cache key is `path` + sorted params (order-independent, deterministic). Each plugin instance owns its cache, so config hot-reload gets a fresh cache.
- `httpPost()` is **never** cached (not idempotent).
- Failed GETs are not cached (the fetcher throws before the value is stored).
- `cacheTtlSeconds` is **optional** in the schema (not `.default(0)`) to avoid breaking existing `GlobalConfig` literals; absent is treated as `0`.
- The Tautulli GeoIP per-IP cache was already implemented separately and is unchanged.

Design spec and implementation plan committed under `docs/superpowers/`.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [ ] Dependencies update

## Checklist
- [x] I have tested my changes locally
- [x] I have added/updated tests if needed
- [x] Code coverage is maintained or improved
- [x] Lint passes (`npm run lint`)
- [x] Tests pass (`npm test`) — 721 tests passing

## Related Issues
<!-- none -->
